### PR TITLE
Add Scaffolder Experiment Lab, GitHub OAuth Publishing, and AI Observability

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.venv
+.pytest_cache
+.ruff_cache
+__pycache__
+*.pyc
+.env
+.streamlit
+.agents
+.codex
+tmp
+output
+docs
+test_*.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,16 @@
 __pycache__/
+*.pyc
+.env
+.DS_Store
+.venv/
+.pytest_cache/
+.ruff_cache/
+tmp/
+output/
 .streamlit/secrets.toml
 .streamlit/tulane-educator-cohort-secrets.toml
+.streamlit/github_oauth_fly
 data/model_cache/
 # Data is now tracked for GitHub-based knowledge base persistence
 # !data/uploads/.gitkeep
 # !data/chroma/.gitkeep
-.env
-.DS_Store
-*.pyc
-.streamlit/secrets.toml

--- a/.streamlit/secrets.toml.example
+++ b/.streamlit/secrets.toml.example
@@ -5,6 +5,7 @@
 
 # OPENAI_API_KEY = "your-key-here"
 # OPENAI_BASE_URL = "https://your-custom-endpoint.com/v1"
+# The same names can be placed in a local .env file. AskLit loads .env automatically.
 # ANTHROPIC_API_KEY = "your-key-here"
 # APP_SECRET_KEY = "generate-a-random-string"
 # ADMIN_ROUTE = "my-secret-admin-access"
@@ -21,10 +22,9 @@
 # "app.conversation_starters" = ["What can you help me with?", "Summarize the knowledge base."]
 # "model.provider" = "openai"
 # "model.allow_user_selection" = "true"
-# "model.allowed_models" = "gpt-5.4-nano,gpt-5.4-mini,gpt-5.6-sol,deepseek-v4-pro,grok-4.1-fast-reasoning,llama-4-maverick"
+# "model.allowed_models" = "gpt-5.4-nano,gpt-5.4-mini,gpt-5.6-sol,deepseek-v4-pro,grok-4.1-fast-reasoning,llama-4-maverick,kimi-k2.6,mistral-large-3,phi-4-mini,gpt-4.1-nano,gpt-4.1-mini"
 # "limits.max_output_tokens_hard" = "4000"
 # "limits.max_conversation_turns" = "30"
-# GitHub Scaffolder Secrets (Optional)
+# GitHub Scaffolder OAuth app (Optional)
+# Enable Device Flow in the OAuth app settings. No client secret is deployed.
 # GITHUB_CLIENT_ID = "your-github-client-id"
-# GITHUB_CLIENT_SECRET = "your-github-client-secret"
-# GITHUB_REDIRECT_URI = "https://your-app.streamlit.app"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,24 @@ FROM python:3.11-slim
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y \
-    build-essential \
     curl \
-    software-properties-common \
-    git \
     libgomp1 \
     && rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt .
-RUN pip3 install -r requirements.txt
+COPY requirements-fly.txt .
+RUN pip3 install --no-cache-dir \
+      --index-url https://download.pytorch.org/whl/cpu \
+      torch==2.7.1 \
+    && pip3 install --no-cache-dir -r requirements-fly.txt
 
 COPY . .
+
+RUN mkdir -p /opt/asklit-seed-data \
+    && cp -a /app/data/. /opt/asklit-seed-data/ \
+    && chmod +x /app/scripts/start-container.sh
 
 EXPOSE 8501
 
 HEALTHCHECK CMD curl --fail http://localhost:8501/_stcore/health
 
-ENTRYPOINT ["streamlit", "run", "app.py", "--server.port=8501", "--server.address=0.0.0.0"]
+ENTRYPOINT ["/app/scripts/start-container.sh"]

--- a/README.md
+++ b/README.md
@@ -24,13 +24,16 @@ Before you start, make sure you have:
     *   **Prompt & Knowledge Base Pairings:** Define one or more prompts and the knowledge base each one should search.
     *   **Custom Branding:** Upload your own logo and favicon.
     *   *(Insert Screenshot: Scaffolder Step 1)*
-3.  **AI Configuration:** Choose your model provider (e.g., OpenAI) and the model name (e.g., `gpt-4o`).
+3.  **AI Configuration:** Choose your model provider (e.g., OpenAI) and the model name (the default is `gpt-5.4-mini`).
 4.  **Knowledge Upload:** Drag and drop your PDFs, Word docs, or Text files. The tool will chunk and embed them locally so you can see your knowledge base built in real-time.
     *   *(Insert Screenshot: Scaffolder Step 3)*
-5.  **Export & Deploy:** 
-    *   **Connect GitHub:** Click the button to authorize AskLit to create a repo for you.
-    *   **Secrets Generator:** Copy the pre-formatted TOML block from the "Deployment Secrets" box. Use the built-in **Password Hasher** if you need to set a password.
-    *   **Push:** Click "Create Repo & Push". This creates a private repository on your account with all your settings and documents pre-indexed.
+5.  **Experiment Lab:** Enter one representative question, select prompts, knowledge bases, and models, then compare the answers, retrieved passages, latency, and approximate tokens. The lab runs every selected combination and does not add experiment history to the exported app.
+    *   AskLit identifies Azure AI and APIM URLs even when they use the `openai` provider alias. For small OpenAI-compatible `/models` responses, the lab shows the returned models directly. Azure `/models` responses are treated as catalog entries—not proof of deployment—so Azure experiments use the configured deployment allowlist instead.
+    *   For a different Azure account, set `"model.allowed_models"` in Streamlit secrets or `MODEL_ALLOWED_MODELS` in `.env` to the deployment names that account actually exposes.
+6.  **Export & Deploy:**
+    *   **Connect GitHub:** Click the button, enter AskLit's one-time code on GitHub, and approve repository access.
+    *   **Secrets Generator:** Copy the pre-formatted TOML block from **Deployment Settings & Secrets**. Passwords entered in the Identity step are hashed automatically and inserted into this block.
+    *   **Push:** Click "Create Repo & Push". This creates a public repository by default with your settings and documents pre-indexed. Select the private-repository checkbox first if your Streamlit plan supports private repositories.
 
 ---
 
@@ -45,7 +48,7 @@ In your Streamlit Cloud dashboard, go to **Settings > Secrets** and paste your c
 ```toml
 OPENAI_API_KEY = "sk-..."
 ADMIN_ROUTE = "manage" # Your secret admin URL parameter
-ADMIN_PASSWORD_HASH = "..." # Generate this using the Hash Tool
+ADMIN_PASSWORD_HASH = "..." # Generated automatically by the scaffolder
 "app.disable_admin" = "false" # Set to true to completely hide admin pages
 ```
 
@@ -56,6 +59,10 @@ OPENAI_API_KEY = "your-provider-key"
 OPENAI_BASE_URL = "https://openrouter.ai/api/v1"
 "model.name" = "anthropic/claude-3-opus" # Use the provider's specific model string
 ```
+
+The scaffolder exposes this as **Use a custom OpenAI-compatible endpoint** in
+the AI Model step. It exports the URL and a placeholder key, never the
+scaffolder host's own credential.
 
 ### 3. Limited Azure educator credentials
 

--- a/admin/logs.py
+++ b/admin/logs.py
@@ -12,7 +12,7 @@ def main():
         st.error("Access denied. Please login.")
         st.stop()
 
-    tab1, tab2 = st.tabs(["Conversations", "Rate Limit Events"])
+    tab1, tab2, tab3 = st.tabs(["Conversations", "AI Calls", "Rate Limit Events"])
 
     with tab1:
         st.header("Recent Conversations")
@@ -47,6 +47,48 @@ def main():
         conn.close()
 
     with tab2:
+        st.header("AI Call Diagnostics")
+        conn = get_connection()
+        df_ai = pd.read_sql_query(
+            """
+            SELECT id, run_id, source, provider, model, prompt_key, knowledgebase,
+                   status, stage, error_type, error_message, latency_ms,
+                   tokens_in, tokens_out, created_at
+            FROM ai_call_events
+            ORDER BY created_at DESC, id DESC
+            LIMIT 200
+            """,
+            conn,
+        )
+        if not df_ai.empty:
+            summary_columns = [
+                "created_at",
+                "status",
+                "stage",
+                "source",
+                "provider",
+                "model",
+                "latency_ms",
+                "run_id",
+            ]
+            st.dataframe(df_ai[summary_columns], use_container_width=True)
+            failed = df_ai[df_ai["status"] == "failed"]
+            for _, row in failed.iterrows():
+                with st.expander(
+                    f"{row['model']} · {row['stage']} · {row['created_at']}"
+                ):
+                    st.write(f"**Run ID:** `{row['run_id']}`")
+                    st.write(f"**Error type:** {row['error_type'] or 'Unknown'}")
+                    st.write(row["error_message"] or "No error details were recorded.")
+                    st.caption(
+                        f"Prompt: {row['prompt_key'] or 'N/A'} · "
+                        f"Knowledge base: {row['knowledgebase'] or 'N/A'}"
+                    )
+        else:
+            st.info("No AI calls logged yet.")
+        conn.close()
+
+    with tab3:
         st.header("Rate Limit Events")
         conn = get_connection()
         df_rl = pd.read_sql_query(

--- a/admin/settings.py
+++ b/admin/settings.py
@@ -112,7 +112,7 @@ def main():
 
         model_name = st.text_input(
             "Model Name / Deployment ID",
-            value=get_setting("model.name", "gpt-5-nano"),
+            value=get_setting("model.name", "gpt-5.4-mini"),
             help="The name of the model or the Azure Deployment ID.",
         )
 

--- a/asklit/config.py
+++ b/asklit/config.py
@@ -4,6 +4,13 @@ import toml
 import streamlit as st
 from asklit.db import get_connection
 
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    pass
+
 DEFAULT_CONFIG_PATH = os.path.join("config", "defaults.toml")
 _MISSING = object()
 
@@ -105,6 +112,15 @@ def get_api_key(provider):
 
 
 def get_base_url(provider):
-    """Retrieve custom base URL for a specific provider from secrets."""
+    """Retrieve a provider URL override from secrets or generated model config."""
     key_name = f"{provider.upper()}_BASE_URL"
-    return get_secret_value(key_name, None)
+    secret_url = get_secret_value(key_name, _MISSING)
+    if secret_url is not _MISSING and str(secret_url).strip():
+        return str(secret_url).strip()
+
+    configured_provider = str(get_setting("model.provider", "")).strip()
+    if str(provider).strip() == configured_provider:
+        configured_url = get_setting("model.base_url", None)
+        if configured_url and str(configured_url).strip():
+            return str(configured_url).strip()
+    return None

--- a/asklit/db.py
+++ b/asklit/db.py
@@ -142,6 +142,30 @@ def init_db(db_path=None):
     )
     """)
 
+    # Structured diagnostics for model and retrieval calls.
+    cursor.execute("""
+    CREATE TABLE IF NOT EXISTS ai_call_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        run_id TEXT NOT NULL,
+        source TEXT NOT NULL,
+        provider TEXT,
+        model TEXT,
+        prompt_key TEXT,
+        knowledgebase TEXT,
+        status TEXT NOT NULL,
+        stage TEXT NOT NULL,
+        error_type TEXT,
+        error_message TEXT,
+        latency_ms INTEGER,
+        tokens_in INTEGER,
+        tokens_out INTEGER,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )
+    """)
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_ai_call_events_created_at ON ai_call_events (created_at)"
+    )
+
     # Rate limit events
     cursor.execute("""
     CREATE TABLE IF NOT EXISTS rate_limit_events (

--- a/asklit/experiments.py
+++ b/asklit/experiments.py
@@ -1,0 +1,86 @@
+from itertools import product
+
+
+MAX_CONTEXT_CHARS = 8000
+
+
+def build_experiment_messages(system_prompt, user_query, context_chunks):
+    """Build a one-turn RAG request from an in-progress scaffold prompt."""
+    context_parts = []
+    current_length = 0
+    for index, chunk in enumerate(context_chunks):
+        content = str(chunk.get("content", "")).strip()
+        if len(content) < 80:
+            continue
+        if current_length + len(content) > MAX_CONTEXT_CHARS:
+            break
+        context_parts.append(f"--- SOURCE {index + 1} ---\n{content}")
+        current_length += len(content)
+
+    context = "\n\n".join(context_parts)
+    full_system_prompt = (
+        f"{system_prompt}\n\n"
+        f"RELEVANT CONTEXT FROM THE KNOWLEDGE BASE:\n{context}\n\n"
+        "INSTRUCTIONS FOR USING CONTEXT:\n"
+        "1. When context is provided and it is relevant, ground the answer in that context before adding general background.\n"
+        "2. If the context only partially answers the question, say what the context supports and then add any clearly labeled general guidance.\n"
+        "3. If the context does not contain the answer, or if the user is asking a general question, use your general knowledge to provide a helpful response."
+    )
+    return [
+        {"role": "system", "content": full_system_prompt},
+        {"role": "user", "content": user_query},
+    ]
+
+
+def parse_model_names(value):
+    """Normalize comma- or newline-separated model names without duplicates."""
+    if isinstance(value, str):
+        candidates = value.replace("\n", ",").split(",")
+    else:
+        candidates = value or []
+
+    models = []
+    seen = set()
+    for candidate in candidates:
+        model = str(candidate).strip()
+        if model and model not in seen:
+            models.append(model)
+            seen.add(model)
+    return models
+
+
+def build_experiment_matrix(prompt_profiles, prompt_keys, knowledgebase_keys, models):
+    """Return the requested prompt × knowledge base × model combinations."""
+    profiles_by_key = {profile["key"]: profile for profile in prompt_profiles}
+    prompts = [profiles_by_key[key] for key in prompt_keys if key in profiles_by_key]
+    knowledgebases = [
+        profiles_by_key[key] for key in knowledgebase_keys if key in profiles_by_key
+    ]
+    return [
+        {
+            "prompt": prompt_profile,
+            "knowledgebase": knowledgebase_profile,
+            "model": model,
+        }
+        for prompt_profile, knowledgebase_profile, model in product(
+            prompts, knowledgebases, parse_model_names(models)
+        )
+    ]
+
+
+def response_text(response):
+    """Extract text from a non-streaming LiteLLM response."""
+    choices = getattr(response, "choices", None)
+    if not choices and isinstance(response, dict):
+        choices = response.get("choices")
+    if not choices:
+        return ""
+
+    choice = choices[0]
+    message = getattr(choice, "message", None)
+    if message is None and isinstance(choice, dict):
+        message = choice.get("message", {})
+    content = getattr(message, "content", None)
+    if content is None and isinstance(message, dict):
+        content = message.get("content")
+    return str(content or "")

--- a/asklit/github.py
+++ b/asklit/github.py
@@ -1,0 +1,201 @@
+"""GitHub OAuth device flow and repository publishing helpers."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import Callable
+
+import requests
+
+
+GITHUB_API_URL = "https://api.github.com"
+GITHUB_DEVICE_CODE_URL = "https://github.com/login/device/code"
+GITHUB_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
+GITHUB_API_VERSION = "2022-11-28"
+MAX_CONTENT_API_FILE_BYTES = 20 * 1024 * 1024
+PUBLISH_IGNORED_PARTS = {
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".venv",
+    "venv",
+    "node_modules",
+    ".DS_Store",
+    ".coverage",
+    "htmlcov",
+}
+PUBLISH_IGNORED_SUFFIXES = (".pyc", ".pyo")
+
+
+class GitHubError(RuntimeError):
+    """A safe, user-displayable GitHub integration error."""
+
+
+def _response_error(response, fallback):
+    try:
+        payload = response.json()
+    except (ValueError, TypeError):
+        payload = {}
+    message = payload.get("error_description") or payload.get("message") or fallback
+    return f"{message} (GitHub returned HTTP {response.status_code})."
+
+
+def _api_headers(token):
+    return {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+    }
+
+
+def request_device_code(client_id, timeout=20, http=requests):
+    """Begin GitHub's OAuth device flow without navigating away from Streamlit."""
+    response = http.post(
+        GITHUB_DEVICE_CODE_URL,
+        headers={"Accept": "application/json"},
+        data={"client_id": client_id, "scope": "repo"},
+        timeout=timeout,
+    )
+    if response.status_code != 200:
+        raise GitHubError(_response_error(response, "Could not start GitHub authorization"))
+    payload = response.json()
+    required = {"device_code", "user_code", "verification_uri", "expires_in"}
+    if not required.issubset(payload):
+        raise GitHubError("GitHub returned an incomplete device authorization response.")
+    return payload
+
+
+def poll_device_token(client_id, device_code, timeout=20, http=requests):
+    """Check a pending device authorization once.
+
+    Returns a status dictionary so the UI can ask the user to retry without
+    blocking a Streamlit worker in a polling loop.
+    """
+    response = http.post(
+        GITHUB_ACCESS_TOKEN_URL,
+        headers={"Accept": "application/json"},
+        data={
+            "client_id": client_id,
+            "device_code": device_code,
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+        },
+        timeout=timeout,
+    )
+    if response.status_code != 200:
+        raise GitHubError(_response_error(response, "Could not complete GitHub authorization"))
+    payload = response.json()
+    if payload.get("access_token"):
+        return {"status": "complete", "access_token": payload["access_token"]}
+
+    error = payload.get("error")
+    if error in {"authorization_pending", "slow_down"}:
+        return {
+            "status": "pending",
+            "message": payload.get("error_description")
+            or "GitHub authorization is still pending.",
+        }
+    if error == "access_denied":
+        return {"status": "denied", "message": "GitHub authorization was denied."}
+    if error == "expired_token":
+        return {"status": "expired", "message": "The GitHub device code expired."}
+    raise GitHubError(payload.get("error_description") or "GitHub authorization failed.")
+
+
+def get_authenticated_user(token, timeout=20, http=requests):
+    response = http.get(
+        f"{GITHUB_API_URL}/user",
+        headers=_api_headers(token),
+        timeout=timeout,
+    )
+    if response.status_code != 200:
+        raise GitHubError(_response_error(response, "GitHub authorization is invalid"))
+    return response.json()
+
+
+def collect_publish_files(directory):
+    """Return deterministic, preflighted files for the Contents API."""
+    root = Path(directory).resolve()
+    if not root.is_dir():
+        raise GitHubError("The generated project directory is unavailable.")
+
+    files = []
+    for path in sorted(root.rglob("*")):
+        relative_path = path.relative_to(root)
+        if any(part in PUBLISH_IGNORED_PARTS for part in relative_path.parts):
+            continue
+        if path.name.endswith(PUBLISH_IGNORED_SUFFIXES):
+            continue
+        if path.is_symlink():
+            raise GitHubError(f"Generated project contains an unsupported link: {path.name}")
+        if not path.is_file():
+            continue
+        relative = relative_path.as_posix()
+        size = path.stat().st_size
+        if size > MAX_CONTENT_API_FILE_BYTES:
+            raise GitHubError(
+                f"{relative} is larger than the 20 MB direct-publishing limit. "
+                "Use the ZIP download for this project."
+            )
+        files.append((relative, path))
+
+    if not files:
+        raise GitHubError("The generated project contains no files to publish.")
+    # Initializing an empty repository with README makes the branch behavior
+    # predictable. Fall back to the first path if a README is not present.
+    files.sort(key=lambda item: (item[0].lower() != "readme.md", item[0]))
+    return files
+
+
+def publish_directory(
+    token,
+    repo_name,
+    directory,
+    *,
+    private=False,
+    timeout=20,
+    http=requests,
+    progress: Callable[[int, int, str], None] | None = None,
+):
+    """Create a repository and publish a generated bundle serially."""
+    files = collect_publish_files(directory)
+    response = http.post(
+        f"{GITHUB_API_URL}/user/repos",
+        headers=_api_headers(token),
+        json={"name": repo_name, "private": private, "auto_init": False},
+        timeout=timeout,
+    )
+    if response.status_code != 201:
+        raise GitHubError(_response_error(response, "Could not create the repository"))
+
+    repository = response.json()
+    full_name = repository["full_name"]
+    default_branch = repository.get("default_branch") or "main"
+    total = len(files)
+
+    for index, (relative, path) in enumerate(files):
+        with path.open("rb") as source:
+            content = base64.b64encode(source.read()).decode("ascii")
+        body = {"message": f"Add {relative}", "content": content}
+        # Omitting branch on the first Contents API call initializes an empty repo.
+        if index:
+            body["branch"] = default_branch
+        put_response = http.put(
+            f"{GITHUB_API_URL}/repos/{full_name}/contents/{relative}",
+            headers=_api_headers(token),
+            json=body,
+            timeout=timeout,
+        )
+        if put_response.status_code not in {200, 201}:
+            raise GitHubError(
+                _response_error(put_response, f"Could not publish {relative}")
+            )
+        if progress:
+            progress(index + 1, total, relative)
+
+    return {
+        "full_name": full_name,
+        "html_url": repository.get("html_url") or f"https://github.com/{full_name}",
+        "files_published": total,
+    }

--- a/asklit/llm.py
+++ b/asklit/llm.py
@@ -1,5 +1,6 @@
 import litellm
 from asklit.config import get_api_key, get_setting, get_base_url
+from asklit.observability import logger, safe_error_message
 
 
 def _get_positive_int_setting(key, default):
@@ -36,15 +37,27 @@ def get_allowed_models():
     return [str(model).strip() for model in models if str(model).strip()]
 
 
-def call_llm(messages, stream=True, max_tokens_override=None, model_override=None):
+def call_llm(
+    messages,
+    stream=True,
+    max_tokens_override=None,
+    model_override=None,
+    provider_override=None,
+    enforce_model_allowlist=True,
+):
     """Call the configured LLM provider using LiteLLM."""
-    configured_model = get_setting("model.name", "gpt-5-nano")
+    configured_model = get_setting("model.name", "gpt-5.4-mini")
     model = str(model_override or configured_model).strip()
     allowed_models = get_allowed_models()
     is_configured_model = model == str(configured_model).strip()
-    if model_override and not is_configured_model and model not in allowed_models:
+    if (
+        enforce_model_allowlist
+        and model_override
+        and not is_configured_model
+        and model not in allowed_models
+    ):
         raise ValueError("The selected model is not enabled for this AskLit instance.")
-    provider = get_setting("model.provider", "openai")
+    provider = str(provider_override or get_setting("model.provider", "openai")).strip()
     temperature = float(get_setting("model.temperature", 1.0))
     max_tokens = _bounded_max_tokens(max_tokens_override)
     disable_temp_setting = get_setting("model.disable_temperature", "false") == "true"
@@ -105,8 +118,18 @@ def call_llm(messages, stream=True, max_tokens_override=None, model_override=Non
             "model.reasoning_effort", "low"
         )
 
-    response = litellm.completion(**completion_kwargs)
-    return response
+    try:
+        return litellm.completion(**completion_kwargs)
+    except Exception as exc:
+        logger.error(
+            "LLM request failed provider=%s model=%s stream=%s error_type=%s error=%s",
+            provider,
+            model,
+            stream,
+            type(exc).__name__,
+            safe_error_message(exc),
+        )
+        raise
 
 
 def estimate_tokens(text):

--- a/asklit/models.py
+++ b/asklit/models.py
@@ -1,0 +1,127 @@
+from urllib.parse import urlparse
+
+import requests
+
+
+MODEL_DISCOVERY_TIMEOUT_SECONDS = 8
+AZURE_HOST_SUFFIXES = (
+    ".cognitiveservices.azure.com",
+    ".openai.azure.com",
+    ".services.ai.azure.com",
+    ".azure-api.net",
+)
+
+
+def normalize_openai_base_url(value):
+    """Validate and normalize a user-configured OpenAI-compatible base URL."""
+    value = str(value or "").strip()
+    if not value:
+        return "", None
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return "", "Enter a complete http:// or https:// endpoint URL."
+    if parsed.username or parsed.password:
+        return "", "Do not put credentials in the endpoint URL."
+    if parsed.query or parsed.fragment:
+        return "", "The endpoint URL cannot contain a query string or fragment."
+    return value.rstrip("/"), None
+
+
+def describe_openai_compatible_endpoint(provider, base_url):
+    """Describe the service behind a provider alias without changing its routing."""
+    host = (urlparse(str(base_url or "")).hostname or "").lower()
+    if host.endswith(".azure-api.net"):
+        return "Azure API Management (OpenAI-compatible)"
+    if host.endswith(AZURE_HOST_SUFFIXES[:-1]):
+        return "Azure AI (OpenAI-compatible)"
+    if provider == "openai" and not base_url:
+        return "OpenAI"
+    if provider == "openai":
+        return "Custom OpenAI-compatible endpoint"
+    return str(provider or "Unknown provider")
+
+
+def model_discovery_url(provider, base_url):
+    if base_url:
+        return f"{str(base_url).rstrip('/')}/models"
+    if provider == "openai":
+        return "https://api.openai.com/v1/models"
+    return None
+
+
+def discover_available_models(provider, base_url, api_key, timeout=None):
+    """Query an OpenAI-compatible /models endpoint and normalize its model IDs."""
+    label = describe_openai_compatible_endpoint(provider, base_url)
+    url = model_discovery_url(provider, base_url)
+    result = {
+        "endpoint_label": label,
+        "endpoint_host": (urlparse(str(base_url or url or "")).hostname or ""),
+        "models": [],
+        "error": None,
+        "is_azure": label.startswith("Azure"),
+    }
+    if not url:
+        result["error"] = (
+            "This provider does not expose an OpenAI-compatible model-list URL."
+        )
+        return result
+    if not api_key:
+        result["error"] = "No API credential is configured for model discovery."
+        return result
+
+    headers = {"Authorization": f"Bearer {api_key}"}
+    if result["is_azure"]:
+        headers["api-key"] = api_key
+    if provider == "azure_apim":
+        headers["Ocp-Apim-Subscription-Key"] = api_key
+
+    try:
+        response = requests.get(
+            url,
+            headers=headers,
+            timeout=timeout or MODEL_DISCOVERY_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        items = payload.get("data", []) if isinstance(payload, dict) else []
+        models = []
+        seen = set()
+        for item in items:
+            model_id = item.get("id") if isinstance(item, dict) else None
+            model_id = str(model_id or "").strip()
+            if model_id and model_id not in seen:
+                seen.add(model_id)
+                models.append(model_id)
+        result["models"] = sorted(models, key=str.casefold)
+    except requests.RequestException as exc:
+        status_code = getattr(getattr(exc, "response", None), "status_code", None)
+        result["error"] = (
+            f"Model discovery returned HTTP {status_code}."
+            if status_code
+            else f"Model discovery failed: {type(exc).__name__}."
+        )
+    except (TypeError, ValueError):
+        result["error"] = "The model endpoint returned an invalid response."
+    return result
+
+
+def choose_model_options(discovery, configured_models, display_limit=20):
+    """Prefer verified small lists, but never treat Azure's catalog as deployments."""
+    configured = []
+    seen = set()
+    for item in configured_models or []:
+        model = str(item).strip()
+        if model and model not in seen:
+            seen.add(model)
+            configured.append(model)
+
+    discovered = discovery.get("models", [])
+    if discovery.get("is_azure"):
+        if 0 < len(configured) <= display_limit:
+            return configured, "configured Azure deployment allowlist"
+        return [], None
+    if 0 < len(discovered) <= display_limit:
+        return discovered, "endpoint model list"
+    if 0 < len(configured) <= display_limit:
+        return configured, "configured models"
+    return [], None

--- a/asklit/observability.py
+++ b/asklit/observability.py
@@ -1,0 +1,102 @@
+import logging
+import re
+
+from asklit.db import get_connection, init_db
+
+
+logger = logging.getLogger("asklit.ai")
+MAX_ERROR_LENGTH = 1200
+SECRET_PATTERNS = [
+    re.compile(
+        r"(?i)(api[-_ ]?key|authorization|subscription[-_ ]?key)(\s*[:=]\s*)([^\s,;]+)"
+    ),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{12,}\b"),
+]
+
+
+def safe_error_message(error):
+    """Return a useful bounded error message with common credential forms removed."""
+    message = str(error).replace("\n", " ").strip()
+    for pattern in SECRET_PATTERNS:
+        if pattern.groups >= 3:
+            message = pattern.sub(r"\1\2[REDACTED]", message)
+        else:
+            message = pattern.sub("[REDACTED]", message)
+    return message[:MAX_ERROR_LENGTH] or "No error details were provided."
+
+
+def log_ai_call_event(
+    *,
+    run_id,
+    source,
+    provider,
+    model,
+    status,
+    stage="completion",
+    prompt_key=None,
+    knowledgebase=None,
+    error=None,
+    latency_ms=None,
+    tokens_in=None,
+    tokens_out=None,
+):
+    """Persist safe AI-call diagnostics and mirror them to the server log."""
+    error_type = type(error).__name__ if error is not None else None
+    error_message = safe_error_message(error) if error is not None else None
+    log_method = logger.error if status == "failed" else logger.info
+    log_method(
+        "AI call %s run_id=%s source=%s stage=%s provider=%s model=%s "
+        "prompt=%s knowledgebase=%s latency_ms=%s error_type=%s error=%s",
+        status,
+        run_id,
+        source,
+        stage,
+        provider,
+        model,
+        prompt_key,
+        knowledgebase,
+        latency_ms,
+        error_type,
+        error_message,
+    )
+
+    conn = None
+    try:
+        init_db()
+        conn = get_connection()
+        conn.execute(
+            """
+            INSERT INTO ai_call_events
+                (run_id, source, provider, model, prompt_key, knowledgebase,
+                 status, stage, error_type, error_message, latency_ms,
+                 tokens_in, tokens_out)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                run_id,
+                source,
+                provider,
+                model,
+                prompt_key,
+                knowledgebase,
+                status,
+                stage,
+                error_type,
+                error_message,
+                latency_ms,
+                tokens_in,
+                tokens_out,
+            ),
+        )
+        conn.commit()
+    except Exception as logging_error:
+        logger.error(
+            "Failed to persist AI call run_id=%s error=%s",
+            run_id,
+            safe_error_message(logging_error),
+        )
+    finally:
+        if conn is not None:
+            conn.close()
+
+    return error_message

--- a/asklit/rag.py
+++ b/asklit/rag.py
@@ -101,11 +101,11 @@ def delete_document_from_index(document_id):
     collection.delete(where={"document_id": document_id})
 
 
-def resolve_document_filter(knowledgebase=None, connected_files=None):
+def resolve_document_filter(knowledgebase=None, connected_files=None, db_path=None):
     knowledgebase = knowledgebase or DEFAULT_KNOWLEDGEBASE
     connected_files = connected_files or []
 
-    conn = get_connection()
+    conn = get_connection(db_path=db_path)
     cursor = conn.cursor()
     if connected_files:
         placeholders = ",".join("?" for _ in connected_files)
@@ -129,7 +129,11 @@ def resolve_document_filter(knowledgebase=None, connected_files=None):
 
 
 def query_keyword_index(
-    query_text, n_results=3, knowledgebase=None, connected_files=None
+    query_text,
+    n_results=3,
+    knowledgebase=None,
+    connected_files=None,
+    db_path=None,
 ):
     terms = [
         term
@@ -139,7 +143,7 @@ def query_keyword_index(
     if not terms:
         return []
 
-    conn = get_connection()
+    conn = get_connection(db_path=db_path)
     cursor = conn.cursor()
     params = [knowledgebase or DEFAULT_KNOWLEDGEBASE]
     files_clause = ""
@@ -191,16 +195,25 @@ def query_keyword_index(
     return scored[:n_results]
 
 
-def query_index(query_text, n_results=None, knowledgebase=None, connected_files=None):
+def query_index(
+    query_text,
+    n_results=None,
+    knowledgebase=None,
+    connected_files=None,
+    db_path=None,
+    chroma_path=None,
+):
     if n_results is None:
         n_results = int(get_setting("retrieval.top_k", 5))
     knowledgebase = knowledgebase or DEFAULT_KNOWLEDGEBASE
     connected_files = connected_files or []
-    allowed_document_ids = resolve_document_filter(knowledgebase, connected_files)
+    allowed_document_ids = resolve_document_filter(
+        knowledgebase, connected_files, db_path=db_path
+    )
     if not allowed_document_ids:
         return []
 
-    collection = get_collection()
+    collection = get_collection(chroma_path=chroma_path)
     vector_n_results = max(n_results * 6, 50)
     query_kwargs = {"query_texts": [query_text], "n_results": vector_n_results}
     if knowledgebase != DEFAULT_KNOWLEDGEBASE:
@@ -231,6 +244,7 @@ def query_index(query_text, n_results=None, knowledgebase=None, connected_files=
         n_results=min(3, n_results),
         knowledgebase=knowledgebase,
         connected_files=connected_files,
+        db_path=db_path,
     )
     combined_results = []
     seen = set()

--- a/chat_ui.py
+++ b/chat_ui.py
@@ -208,7 +208,7 @@ def render_prompt_selector(prompt_configs):
 
 
 def render_model_selector():
-    configured_model = str(get_setting("model.name", "gpt-5-nano"))
+    configured_model = str(get_setting("model.name", "gpt-5.4-mini"))
     selection_enabled = (
         str(get_setting("model.allow_user_selection", "false")).lower() == "true"
     )

--- a/config/apim-api-policy.xml
+++ b/config/apim-api-policy.xml
@@ -1,0 +1,72 @@
+<policies>
+  <inbound>
+    <base />
+    <choose>
+      <when condition="@(!bool.Parse(&quot;{{asklit-gateway-enabled}}&quot;))">
+        <return-response>
+          <set-status code="403" reason="Gateway disabled" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body>{"error":{"message":"The AskLit educator gateway is temporarily disabled.","type":"gateway_disabled"}}</set-body>
+        </return-response>
+      </when>
+    </choose>
+    <set-variable name="requestLength"
+      value="@((context.Request.Body.As&lt;string&gt;(preserveContent: true) ?? string.Empty).Length)" />
+    <choose>
+      <when condition="@((int)context.Variables[&quot;requestLength&quot;] &gt; 200000)">
+        <return-response>
+          <set-status code="413" reason="Request too large" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body>{"error":{"message":"Request exceeds the AskLit educator limit.","type":"request_too_large"}}</set-body>
+        </return-response>
+      </when>
+    </choose>
+    <set-variable name="requestAllowed" value="@{
+      try
+      {
+        var body = context.Request.Body.As&lt;Newtonsoft.Json.Linq.JObject&gt;(preserveContent: true);
+        if (body == null) { return false; }
+        var model = (string)body[&quot;model&quot;];
+        var modelAllowed =
+          model == &quot;gpt-5.4-nano&quot; ||
+          model == &quot;gpt-5.4-mini&quot; ||
+          model == &quot;gpt-5.6-sol&quot; ||
+          model == &quot;deepseek-v4-pro&quot; ||
+          model == &quot;grok-4.1-fast-reasoning&quot; ||
+          model == &quot;llama-4-maverick&quot; ||
+          model == &quot;kimi-k2.6&quot; ||
+          model == &quot;mistral-large-3&quot; ||
+          model == &quot;phi-4-mini&quot; ||
+          model == &quot;gpt-4.1-nano&quot; ||
+          model == &quot;gpt-4.1-mini&quot;;
+        var maxTokens = (int?)body[&quot;max_completion_tokens&quot;] ?? (int?)body[&quot;max_tokens&quot;];
+        return modelAllowed &amp;&amp; maxTokens.HasValue &amp;&amp; maxTokens.Value &gt; 0 &amp;&amp;
+          maxTokens.Value &lt;= 4000 &amp;&amp; body[&quot;messages&quot;] != null;
+      }
+      catch
+      {
+        return false;
+      }
+    }" />
+    <choose>
+      <when condition="@(!(bool)context.Variables[&quot;requestAllowed&quot;])">
+        <return-response>
+          <set-status code="403" reason="Request not allowed" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body>{"error":{"message":"The request violates the AskLit educator model or output limits.","type":"policy_restriction"}}</set-body>
+        </return-response>
+      </when>
+    </choose>
+    <set-header name="api-key" exists-action="delete" />
+    <authentication-managed-identity resource="https://cognitiveservices.azure.com" />
+  </inbound>
+  <backend><base /></backend>
+  <outbound><base /></outbound>
+  <on-error><base /></on-error>
+</policies>

--- a/config/apim-product-policy.xml
+++ b/config/apim-product-policy.xml
@@ -1,0 +1,10 @@
+<policies>
+  <inbound>
+    <base />
+    <rate-limit calls="180" renewal-period="60" />
+    <quota calls="2000" bandwidth="500000" renewal-period="2592000" />
+  </inbound>
+  <backend><base /></backend>
+  <outbound><base /></outbound>
+  <on-error><base /></on-error>
+</policies>

--- a/config/defaults.toml
+++ b/config/defaults.toml
@@ -7,7 +7,8 @@ enable_scaffolder = false
 
 [model]
 provider = "openai"
-name = "gpt-5-nano"
+name = "gpt-5.4-mini"
+base_url = ""
 embedding_provider = "openai"
 embedding_model = "text-embedding-3-small"
 temperature = 1.0
@@ -17,7 +18,7 @@ use_local_embeddings = true
 max_tokens = 4000
 reasoning_effort = "low"
 allow_user_selection = false
-allowed_models = "gpt-5.4-nano,gpt-5.4-mini,gpt-5.6-sol,deepseek-v4-pro,grok-4.1-fast-reasoning,llama-4-maverick"
+allowed_models = "gpt-5.4-nano,gpt-5.4-mini,gpt-5.6-sol,deepseek-v4-pro,grok-4.1-fast-reasoning,llama-4-maverick,kimi-k2.6,mistral-large-3,phi-4-mini,gpt-4.1-nano,gpt-4.1-mini"
 
 [retrieval]
 top_k = 5

--- a/docs/azure-apim-educator-gateway.md
+++ b/docs/azure-apim-educator-gateway.md
@@ -35,7 +35,18 @@ gpt-5.6-sol
 deepseek-v4-pro
 grok-4.1-fast-reasoning
 llama-4-maverick
+kimi-k2.6
+mistral-large-3
+phi-4-mini
+gpt-4.1-nano
+gpt-4.1-mini
 ```
+
+Qwen is not exposed in this deployment. In East US 2, Azure currently presents
+`Qwen3-32B` as a fine-tuning base model rather than an ordinary hosted inference
+deployment, and the resource provider rejects a `GlobalStandard` inference
+deployment for it. Add Qwen to this list and the API policy only after Azure
+offers a deployable inference SKU in the selected region.
 
 The FLUX image deployment was removed and is not exposed.
 
@@ -48,19 +59,19 @@ It does **not** support `llm-token-limit`, `rate-limit-by-key`, or
 
 For this pilot, the shared cohort subscription currently receives:
 
-- 30 calls per minute
-- 600 calls per 2,592,000-second (30-day) subscription window
-- 150,000 KB aggregate request/response bandwidth in that window
+- 180 calls per minute
+- 2,000 calls per 2,592,000-second (30-day) subscription window
+- 500,000 KB aggregate request/response bandwidth in that window
 - 200,000 characters per serialized request body
 - 4,000 requested output tokens per call
-- access to the six approved chat deployments only
+- access to the eleven approved chat deployments only
 
 The quota window is a rolling APIM subscription period, not a calendar month.
 The $20 Azure budget remains calendar-month based. Consumption APIM avoids the
 fixed Basic v2 charge, but model inference is still billed normally.
 
 This is a disclosure-containment control: a stolen key can make at most the
-pool's remaining 600 calls, can be revoked immediately, and cannot call the
+pool's remaining 2,000 calls, can be revoked immediately, and cannot call the
 Azure AI account directly. The Azure budget alert is only a delayed backstop.
 Because the key is shared, one educator can consume the pool and a rotation
 requires updating all twelve educators.
@@ -91,9 +102,9 @@ AZURE_APIM_API_KEY = "<shared cohort APIM subscription key>"
 AZURE_APIM_BASE_URL = "https://tulane-asklit-gateway.azure-api.net/asklit"
 
 "model.provider" = "azure_apim"
-"model.name" = "gpt-5.4-nano"
+"model.name" = "gpt-5.4-mini"
 "model.allow_user_selection" = "true"
-"model.allowed_models" = "gpt-5.4-nano,gpt-5.4-mini,gpt-5.6-sol,deepseek-v4-pro,grok-4.1-fast-reasoning,llama-4-maverick"
+"model.allowed_models" = "gpt-5.4-nano,gpt-5.4-mini,gpt-5.6-sol,deepseek-v4-pro,grok-4.1-fast-reasoning,llama-4-maverick,kimi-k2.6,mistral-large-3,phi-4-mini,gpt-4.1-nano,gpt-4.1-mini"
 "model.max_tokens" = "4000"
 "limits.max_output_tokens_hard" = "4000"
 "limits.max_conversation_turns" = "30"
@@ -183,7 +194,10 @@ Apply this policy to the API. Create the non-secret APIM named value
         var modelAllowed =
           model == &quot;gpt-5.4-nano&quot; || model == &quot;gpt-5.4-mini&quot; ||
           model == &quot;gpt-5.6-sol&quot; || model == &quot;deepseek-v4-pro&quot; ||
-          model == &quot;grok-4.1-fast-reasoning&quot; || model == &quot;llama-4-maverick&quot;;
+          model == &quot;grok-4.1-fast-reasoning&quot; || model == &quot;llama-4-maverick&quot; ||
+          model == &quot;kimi-k2.6&quot; || model == &quot;mistral-large-3&quot; ||
+          model == &quot;phi-4-mini&quot; || model == &quot;gpt-4.1-nano&quot; ||
+          model == &quot;gpt-4.1-mini&quot;;
         var maximum = (int?)body[&quot;max_completion_tokens&quot;] ??
           (int?)body[&quot;max_tokens&quot;];
         return modelAllowed &amp;&amp; maximum.HasValue &amp;&amp;
@@ -212,8 +226,8 @@ the API to that product and create one `educator-cohort` APIM subscription.
 <policies>
   <inbound>
     <base />
-    <rate-limit calls="30" renewal-period="60" />
-    <quota calls="600" bandwidth="150000" renewal-period="2592000" />
+    <rate-limit calls="180" renewal-period="60" />
+    <quota calls="2000" bandwidth="500000" renewal-period="2592000" />
   </inbound>
   <backend><base /></backend>
   <outbound><base /></outbound>
@@ -249,10 +263,10 @@ abuse control; the budget workflow is not.
 - Missing, invalid, or cancelled educator key: HTTP 401
 - Unapproved model or output request above 4,000 tokens: HTTP 403
 - Request body above 200,000 characters: HTTP 413
-- More than 30 calls in a minute: HTTP 429
+- More than 180 calls in a minute: HTTP 429
 - Per-key call or bandwidth quota exhausted: HTTP 403
 - Direct Azure AI request with an account key: HTTP 401
-- All six approved model deployments through APIM: HTTP 200
+- All eleven approved model deployments through APIM: HTTP 200
 - AskLit displays only a generic provider/limit error to non-admin users
 
 APIM counters can overshoot slightly when concurrent requests arrive at

--- a/docs/deploy-to-streamlit/README.md
+++ b/docs/deploy-to-streamlit/README.md
@@ -104,13 +104,28 @@ Open <https://asklit-scaffold.streamlit.app/> in a wide browser window. If the l
 
 ### 1. Name and describe the app
 
-Enter the public-facing title, welcome message, and organization details. Do not enter passwords or API keys here.
+Enter the public-facing title, welcome message, and organization details. If the
+chat is password protected, enter and confirm its password on this screen.
+AskLit immediately replaces the plain password with a PBKDF2 hash and inserts
+that hash into the deployment settings later. Configure the administrator
+password here as well when the admin backend is enabled. Do not enter API keys;
+those belong only in the deployed app's private Streamlit Secrets.
 
 ![AskLit Scaffolder identity and branding screen](screenshots/01-scaffolder-identity.png)
 
 ### 2. Choose the administrator-provided model settings
 
 Choose the model provider and model specified by your program administrator. For a Tulane cohort deployment, use the values supplied with the Tulane configuration rather than guessing.
+
+When using **OpenAI** with a proxy, Azure OpenAI-compatible URL, or another
+compatible service, select **Use a custom OpenAI-compatible endpoint** and enter
+its base URL, including a path such as `/v1` when required. Enter the model name
+accepted by that service. The scaffolder exports the URL but never its own API
+key; add your provider key later in Streamlit's private Secrets settings.
+
+For **Azure APIM**, the current workshop gateway URL is prefilled. You may
+replace it with another OpenAI-compatible APIM gateway URL. The exported app
+receives the selected URL, never the scaffolder's gateway key.
 
 ### 3. Upload a PDF or Word knowledge base
 
@@ -126,13 +141,26 @@ Click the button to process or index the files. Wait for the success message bef
 
 Only upload documents you are allowed to publish. If a generated repository will be public, assume its bundled knowledge-base material will also be public.
 
-### 4. Export to GitHub
+### 4. Optionally compare configurations in the Experiment Lab
 
-Open **Export & Deploy**. Review the checklist, connect GitHub when prompted, and choose a short repository name such as `my-asklit-app`. The scaffolder should create and populate the repository; the end user should not need a GitHub token.
+Open **Experiment Lab** to test one question against different prompts, knowledge bases, and models before exporting. Each combination makes a real model request, so select only the combinations you need. Compare the answers and retrieved sources, then return to earlier steps to adjust your configuration if needed. Experiment results are temporary and are not added to the generated repository.
+
+### 5. Export to GitHub
+
+Open **Export & Deploy**. Review the checklist, connect GitHub when prompted,
+and choose a short repository name such as `my-asklit-app`. AskLit displays a
+one-time code: open the GitHub authorization page, enter that code, approve the
+connection, and return to the still-open AskLit tab. The scaffolder should
+create and populate the repository; the end user should not need to create or
+paste a GitHub token.
 
 ![Export and GitHub options in the scaffolder](screenshots/06-export-github-options.png)
 
-On GitHub, open the new repository and check its visibility beside the repository name. For this free walkthrough, change it to **Public** under **Settings → General → Danger Zone → Change repository visibility** if the scaffolder created it as private. Before doing that, confirm there is no real `.streamlit/secrets.toml` and no confidential source document in the repository.
+The scaffolder creates a **public** repository by default for the simplest
+Streamlit Community Cloud deployment. Before publishing, confirm there is no
+real `.streamlit/secrets.toml` and no confidential source document in the
+project. Select **Make the GitHub repository private** before publishing only if
+your Streamlit account can deploy private repositories.
 
 ## Part 3: Deploy on Streamlit Community Cloud
 
@@ -197,3 +225,23 @@ Ask one question that can be answered from your uploaded PDF or Word document. C
 - The educator's Streamlit account owns the deployed app and its private secrets.
 
 That separation lets educators use the no-code workflow without receiving the scaffolder's central GitHub credentials.
+
+## Scaffolder operator: GitHub OAuth setup
+
+The central scaffolder uses GitHub's OAuth device flow so an authorization does
+not navigate away from and erase an in-progress Streamlit session.
+
+1. In GitHub, open **Settings → Developer settings → OAuth Apps** and register
+   an OAuth app owned by the central account or organization.
+2. Use `https://asklit-scaffold-lab.fly.dev/` for both the homepage and
+   authorization callback URL.
+3. Open the OAuth app's settings and enable **Device Flow**.
+4. Store only its public client ID in the deployment:
+
+   ```bash
+   flyctl secrets set GITHUB_CLIENT_ID=<client-id> --app asklit-scaffold-lab
+   ```
+
+AskLit requests the classic `repo` scope so the educator can optionally select a
+private repository. Repositories are public by default. AskLit does not deploy
+or require the OAuth client secret.

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,46 @@
+app = "asklit-scaffold-lab"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  APP_ENABLE_SCAFFOLDER = "true"
+  APP_ACCESS_MODE = "public"
+  MODEL_PROVIDER = "azure_apim"
+  MODEL_NAME = "gpt-5.4-mini"
+  MODEL_ALLOW_USER_SELECTION = "true"
+  MODEL_ALLOWED_MODELS = "gpt-5.4-nano,gpt-5.4-mini,gpt-5.6-sol,deepseek-v4-pro,grok-4.1-fast-reasoning,llama-4-maverick,kimi-k2.6,mistral-large-3,phi-4-mini,gpt-4.1-nano,gpt-4.1-mini"
+  MODEL_USE_LOCAL_EMBEDDINGS = "true"
+  MODEL_LOCAL_EMBEDDING_MODEL = "all-MiniLM-L6-v2"
+  LIMITS_MAX_OUTPUT_TOKENS_HARD = "4000"
+  LIMITS_MAX_CONVERSATION_TURNS = "30"
+  LIMITS_MAX_PROMPT_LENGTH = "2000"
+
+[http_service]
+  internal_port = 8501
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "connections"
+    soft_limit = 40
+    hard_limit = 60
+
+  [[http_service.checks]]
+    grace_period = "60s"
+    interval = "30s"
+    method = "GET"
+    timeout = "5s"
+    path = "/_stcore/health"
+
+[[vm]]
+  size = "shared-cpu-4x"
+  memory = "4gb"
+
+[[mounts]]
+  source = "asklit_data"
+  destination = "/app/data"

--- a/requirements-fly.txt
+++ b/requirements-fly.txt
@@ -1,0 +1,15 @@
+streamlit
+chromadb
+protobuf==3.20.3
+litellm
+sentence-transformers
+python-dotenv
+pypdf
+docx2txt
+markdown
+beautifulsoup4
+pandas
+toml
+pyyaml
+pycryptodome
+passlib

--- a/runtime/app.py
+++ b/runtime/app.py
@@ -1,23 +1,21 @@
 import streamlit as st
+
 from asklit.config import get_secret_value, get_setting
 from asklit.db import init_db
 
+
 init_db()
 
-# Set page config once at the very top
 st.set_page_config(
     page_title=get_setting("app.title", "AskLit"),
     page_icon=get_setting("branding.favicon_url", "💬"),
     layout="centered",
 )
 
-# 1. Define all possible pages
 chat_page = st.Page(
     "chat_ui.py", title=get_setting("app.title", "AskLit"), icon="💬", default=True
 )
-
 login_page = st.Page("login_ui.py", title="Admin Login", icon="🔐")
-
 admin_settings = st.Page("admin/settings.py", title="Admin Settings", icon="⚙️")
 admin_kb = st.Page("admin/kb.py", title="Knowledge Base", icon="📚")
 admin_logs = st.Page("admin/logs.py", title="Usage Logs", icon="📈")
@@ -30,39 +28,31 @@ def logout():
 
 
 logout_page = st.Page(logout, title="Logout", icon="🚪")
-
-# 2. Build the navigation based on authentication status
-# We use a secret route name from secrets to "unlock" the admin login page
-# Example: If ADMIN_ROUTE = "manage", visiting /?manage will show the login page
 admin_route = get_secret_value("ADMIN_ROUTE", "admin-login")
 disable_admin = str(get_setting("app.disable_admin", "false")).lower() == "true"
-enable_scaffolder = str(get_setting("app.enable_scaffolder", "false")).lower() == "true"
 public_pages = [chat_page]
-if enable_scaffolder:
-    public_pages.append(
-        st.Page("scaffold.py", title="Project Scaffolder", icon="🏗️")
-    )
 
 if admin_route in st.query_params and not disable_admin:
     st.session_state["admin_unlocked"] = True
-    # We don't clear it immediately to ensure the initial load captures it
-    # but we can set a flag.
 
 if st.session_state.get("is_admin_authenticated") and not disable_admin:
-    # Admin View: Show everything
-    pg = st.navigation(
+    navigation = st.navigation(
         {
             "Public": public_pages,
-            "Admin Management": [admin_settings, admin_kb, admin_logs, admin_hash_tool],
+            "Admin Management": [
+                admin_settings,
+                admin_kb,
+                admin_logs,
+                admin_hash_tool,
+            ],
             "Account": [logout_page],
         }
     )
 elif st.session_state.get("admin_unlocked") and not disable_admin:
-    # Hidden Login View: Show Chat + Login + Setup Tools
-    pg = st.navigation({"Chat": public_pages, "System": [login_page, admin_hash_tool]})
+    navigation = st.navigation(
+        {"Chat": public_pages, "System": [login_page, admin_hash_tool]}
+    )
 else:
-    # Pure Public View: Only the production chat flow by default.
-    pg = st.navigation(public_pages)
+    navigation = st.navigation(public_pages)
 
-# 3. Run navigation
-pg.run()
+navigation.run()

--- a/scaffold.py
+++ b/scaffold.py
@@ -5,56 +5,220 @@ import tempfile
 import zipfile
 import toml
 import uuid
-import requests
-import json
 import yaml
-from datetime import datetime
+import time
+from asklit.auth import hash_password
 from asklit.db import get_connection, init_db
+from asklit.experiments import (
+    build_experiment_matrix,
+    build_experiment_messages,
+    parse_model_names,
+    response_text,
+)
 from asklit.ingestion import extract_text, chunk_pages, get_content_hash
-from asklit.rag import add_document_to_index, get_chroma_client, COLLECTION_NAME
-from asklit.config import get_secret_value
+from asklit.github import (
+    GitHubError,
+    get_authenticated_user,
+    poll_device_token,
+    publish_directory,
+    request_device_code,
+)
+from asklit.llm import call_llm, estimate_tokens
+from asklit.models import (
+    choose_model_options,
+    discover_available_models,
+    normalize_openai_base_url,
+)
+from asklit.observability import log_ai_call_event
+from asklit.rag import add_document_to_index, query_index
+from asklit.config import get_api_key, get_base_url, get_secret_value, get_setting
 from asklit.ui import escape_html, safe_url
 
 # Constants
 DEFAULT_REPO_NAME = "my-asklit-app"
 REQUEST_TIMEOUT_SECONDS = 20
-FILES_TO_IGNORE = {
-    ".git",
+RUNTIME_ROOT_FILES = {
+    "runtime/app.py": "app.py",
+    "chat_ui.py": "chat_ui.py",
+    "login_ui.py": "login_ui.py",
+    "requirements.txt": "requirements.txt",
+}
+RUNTIME_DIRECTORIES = ("admin",)
+RUNTIME_ASKLIT_MODULES = (
+    "__init__.py",
+    "auth.py",
+    "config.py",
+    "db.py",
+    "embeddings.py",
+    "ingestion.py",
+    "llm.py",
+    "observability.py",
+    "prompts.py",
+    "rag.py",
+    "rate_limits.py",
+    "ui.py",
+)
+RECURSIVE_ARTIFACT_NAMES = {
     "__pycache__",
     ".pytest_cache",
-    ".streamlit",
-    "data",
-    "scaffold.py",
-    ".env",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".venv",
+    "venv",
     "node_modules",
-    ".agents",
-    ".codex",
+    ".DS_Store",
+    ".coverage",
+    "htmlcov",
+}
+RECURSIVE_ARTIFACT_SUFFIXES = (".pyc", ".pyo")
+SENSITIVE_EXPORT_CONFIG_KEYS = {
+    "api_key",
+    "client_secret",
+    "access_token",
+    "password",
+    "password_hash",
+    "shared_password_hash",
+    "admin_password_hash",
 }
 
 
+def ignore_bundle_artifacts(_directory, names):
+    """Filter generated/runtime artifacts at every depth of a scaffold copy."""
+    return [
+        name
+        for name in names
+        if name in RECURSIVE_ARTIFACT_NAMES
+        or name.endswith(RECURSIVE_ARTIFACT_SUFFIXES)
+    ]
+
+
+def sanitize_export_config(value):
+    """Recursively remove credentials if they ever enter scaffold configuration."""
+    if isinstance(value, dict):
+        sanitized = {}
+        for key, child in value.items():
+            normalized_key = str(key).strip().lower().replace("-", "_")
+            if normalized_key in SENSITIVE_EXPORT_CONFIG_KEYS or normalized_key.endswith(
+                "_api_key"
+            ):
+                continue
+            sanitized[key] = sanitize_export_config(child)
+        return sanitized
+    if isinstance(value, list):
+        return [sanitize_export_config(item) for item in value]
+    return value
+
+
+def render_password_hash_setup(label, state_key, help_text):
+    """Collect a password once, retain only its PBKDF2 hash, and show the result."""
+    configured_hash = st.session_state.get(state_key)
+    if configured_hash:
+        st.success(f"{label} is configured.")
+        st.caption(
+            "Generated password hash (this will be placed in deployment secrets):"
+        )
+        st.code(configured_hash, language=None)
+        if st.button(f"Change {label.lower()}", key=f"change_{state_key}"):
+            st.session_state.pop(state_key, None)
+            st.rerun()
+        return configured_hash
+
+    st.caption(help_text)
+    with st.form(f"form_{state_key}", clear_on_submit=True):
+        password = st.text_input(label, type="password", key=f"input_{state_key}")
+        confirmation = st.text_input(
+            f"Confirm {label.lower()}",
+            type="password",
+            key=f"confirm_{state_key}",
+        )
+        submitted = st.form_submit_button(f"Set {label.lower()}")
+    if submitted:
+        if len(password) < 8:
+            st.error("Use at least 8 characters.")
+        elif password != confirmation:
+            st.error("The passwords do not match.")
+        else:
+            st.session_state[state_key] = hash_password(password)
+            st.rerun()
+    return None
+
+
+@st.cache_data(ttl=300, show_spinner=False)
+def discover_endpoint_models(provider, base_url):
+    """Cache public model metadata without placing credentials in the cache key."""
+    return discover_available_models(
+        provider,
+        base_url,
+        get_api_key(provider),
+    )
+
+
+def get_endpoint_model_choices(provider, configured_models, base_url_override=None):
+    """Choose honest runnable options without mistaking Azure's catalog for deployments."""
+    base_url = (
+        base_url_override
+        if base_url_override is not None
+        else get_base_url(provider)
+    )
+    discovery = discover_endpoint_models(provider, base_url)
+    configured_models = parse_model_names(configured_models)
+
+    choices, choice_source = choose_model_options(discovery, configured_models)
+    return choices, choice_source, discovery
+
+
+def render_endpoint_model_status(discovery, choice_source):
+    host = discovery.get("endpoint_host") or "default endpoint"
+    st.caption(f"Endpoint: {discovery['endpoint_label']} · {host}")
+    count = len(discovery["models"])
+    if discovery["is_azure"] and count:
+        st.caption(
+            f"Azure `/models` returned {count} catalog entries; these are not treated "
+            f"as deployed models. Showing {choice_source or 'manual model entry'}."
+        )
+    elif choice_source:
+        st.caption(f"Showing {choice_source}.")
+    elif discovery["error"]:
+        st.caption(f"Automatic model discovery unavailable: {discovery['error']}")
+    elif count > 20:
+        st.caption(
+            f"The endpoint returned {count} models, so manual entry remains available."
+        )
+
+
 def create_bundle(config_data, data_dir_source):
-    """Creates a temporary directory with all project files and the new config/data."""
+    """Create a deployable chatbot runtime with generated config and data."""
     temp_dir = tempfile.mkdtemp()
     root_dir = os.path.dirname(os.path.abspath(__file__))
 
-    # 1. Copy core files
-    for item in os.listdir(root_dir):
-        if item in FILES_TO_IGNORE:
-            continue
+    # 1. Copy only the production chatbot runtime. Scaffolder, experiment,
+    # OAuth-publishing, test, documentation, and infrastructure files stay out.
+    for source_name, destination_name in RUNTIME_ROOT_FILES.items():
+        shutil.copy2(
+            os.path.join(root_dir, source_name),
+            os.path.join(temp_dir, destination_name),
+        )
 
-        src_path = os.path.join(root_dir, item)
-        dst_path = os.path.join(temp_dir, item)
+    for directory in RUNTIME_DIRECTORIES:
+        shutil.copytree(
+            os.path.join(root_dir, directory),
+            os.path.join(temp_dir, directory),
+            ignore=ignore_bundle_artifacts,
+        )
 
-        if os.path.isdir(src_path):
-            shutil.copytree(src_path, dst_path)
-        else:
-            shutil.copy2(src_path, dst_path)
+    asklit_dir = os.path.join(temp_dir, "asklit")
+    os.makedirs(asklit_dir, exist_ok=True)
+    for filename in RUNTIME_ASKLIT_MODULES:
+        shutil.copy2(
+            os.path.join(root_dir, "asklit", filename),
+            os.path.join(asklit_dir, filename),
+        )
 
     # 2. Write the new defaults.toml
     config_path = os.path.join(temp_dir, "config", "defaults.toml")
     os.makedirs(os.path.dirname(config_path), exist_ok=True)
     # Prompt pairings are written as YAML files under prompts/.
-    toml_data = config_data.copy()
+    toml_data = sanitize_export_config(config_data)
     prompt_profiles = normalize_prompt_profiles(toml_data.pop("prompt_profiles", []))
     toml_data.pop("prompt", None)
     with open(config_path, "w") as f:
@@ -96,7 +260,14 @@ def create_bundle(config_data, data_dir_source):
             "[server]\nheadless = true\nenableCORS = false\nenableXsrfProtection = false\n"
         )
 
-    # 5. Add a README with setup instructions
+    # 5. Add runtime-focused repository metadata and setup instructions.
+    with open(os.path.join(temp_dir, ".gitignore"), "w") as f:
+        f.write(
+            "__pycache__/\n*.py[cod]\n.pytest_cache/\n.mypy_cache/\n.ruff_cache/\n"
+            ".venv/\nvenv/\n.env\n.DS_Store\n.streamlit/secrets.toml\n"
+            "data/model_cache/\n"
+        )
+
     with open(os.path.join(temp_dir, "README.md"), "w") as f:
         f.write(f"# {config_data['app']['title']}\n\n")
         f.write("This app was generated by the AskLit Scaffolder.\n\n")
@@ -175,6 +346,357 @@ def toml_quote(value):
     return toml.dumps({"value": str(value)}).split("=", 1)[1].strip()
 
 
+def generate_deployment_secrets(config_data, password_hashes=None):
+    """Return copy-ready Streamlit secrets with placeholder API credentials."""
+    password_hashes = password_hashes or {}
+    provider = config_data["model"].get("provider", "openai")
+    lines = [
+        "# AskLit deployment secrets",
+        "# Replace every PASTE_... value in Streamlit. Never add this file to GitHub.",
+        f'{provider.upper()}_API_KEY = "PASTE_YOUR_KEY_HERE"',
+    ]
+    if provider == "openai" and config_data["model"].get("base_url"):
+        lines.append(
+            f'OPENAI_BASE_URL = {toml_quote(config_data["model"]["base_url"])}'
+        )
+    if provider == "azure_apim":
+        gateway_url = config_data["model"].get("base_url") or (
+            "https://YOUR-GATEWAY.azure-api.net/asklit"
+        )
+        lines.extend(
+            [
+                f"AZURE_APIM_BASE_URL = {toml_quote(gateway_url)}",
+                "",
+                '"model.provider" = "azure_apim"',
+                f'"model.name" = {toml_quote(config_data["model"].get("name", ""))}',
+                f'"model.allow_user_selection" = {str(config_data["model"].get("allow_user_selection", True)).lower()}',
+                f'"model.allowed_models" = {toml_quote(config_data["model"].get("allowed_models", ""))}',
+                '"model.use_local_embeddings" = true',
+                '"model.local_embedding_model" = "all-MiniLM-L6-v2"',
+                '"limits.max_output_tokens_hard" = "4000"',
+                '"limits.max_conversation_turns" = "30"',
+            ]
+        )
+    lines.extend(["", "# Identity & access", 'ADMIN_ROUTE = "manage"'])
+    if not config_data["app"].get("disable_admin"):
+        lines.append(
+            f"ADMIN_PASSWORD_HASH = {toml_quote(password_hashes.get('admin') or 'PASTE_ADMIN_HASH_HERE')}"
+        )
+    if config_data["app"]["access_mode"] == "password":
+        lines.append(
+            f"SHARED_PASSWORD_HASH = {toml_quote(password_hashes.get('shared') or 'PASTE_SHARED_HASH_HERE')}"
+        )
+    lines.extend(
+        [
+            "",
+            "# App overrides",
+            f'"app.title" = {toml_quote(config_data["app"]["title"])}',
+            f'"app.access_mode" = {toml_quote(config_data["app"]["access_mode"])}',
+            f'"app.disable_admin" = {str(config_data["app"].get("disable_admin", False)).lower()}',
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def ensure_model_defaults(config_data):
+    """Keep Export usable even when someone skips the AI Model step."""
+    model = config_data.setdefault("model", {})
+    model.setdefault("provider", get_setting("model.provider", "openai"))
+    model.setdefault("name", get_setting("model.name", "gpt-5.4-mini"))
+    model.setdefault(
+        "allow_user_selection",
+        str(get_setting("model.allow_user_selection", "false")).lower() == "true",
+    )
+    model.setdefault("allowed_models", get_setting("model.allowed_models", ""))
+    model.setdefault("base_url", "")
+    model.setdefault("use_local_embeddings", True)
+    model.setdefault("local_embedding_model", "all-MiniLM-L6-v2")
+    return config_data
+
+
+def get_scaffold_document_labels(db_path):
+    """Return document labels for experiment citations."""
+    conn = get_connection(db_path=db_path)
+    rows = conn.execute("SELECT id, filename FROM documents").fetchall()
+    conn.close()
+    return {row["id"]: row["filename"] for row in rows}
+
+
+def render_experiment_lab():
+    """Render a small Cartesian prompt/knowledge-base/model comparison lab."""
+    ensure_model_defaults(st.session_state.app_config)
+    profiles = normalize_prompt_profiles(
+        st.session_state.app_config.get("prompt_profiles")
+    )
+    st.session_state.app_config["prompt_profiles"] = profiles
+    model_config = st.session_state.app_config["model"]
+
+    st.header("Step 4: Experiment Lab")
+    st.write(
+        "Ask one question across different prompts, knowledge bases, and models. "
+        "Experiments are temporary and are not included in the exported app."
+    )
+    st.warning(
+        "Each combination makes a real model call using credentials configured for this scaffolder. "
+        "Your provider may charge for these calls."
+    )
+
+    labels = {profile["key"]: profile["label"] for profile in profiles}
+    prompt_keys = st.multiselect(
+        "Prompts",
+        [profile["key"] for profile in profiles],
+        default=[profiles[0]["key"]],
+        format_func=lambda key: labels[key],
+        help="The system prompt to place at the beginning of each test request.",
+    )
+    knowledgebase_keys = st.multiselect(
+        "Knowledge bases",
+        [profile["key"] for profile in profiles],
+        default=[profiles[0]["key"]],
+        format_func=lambda key: (
+            f"{labels[key]} ({next(profile['knowledgebase'] for profile in profiles if profile['key'] == key)})"
+        ),
+        help="Uses the knowledge base and connected-file filters from the selected pairing.",
+    )
+
+    provider_options = [
+        "openai",
+        "azure_apim",
+        "anthropic",
+        "google",
+        "groq",
+        "mistral",
+        "azure",
+    ]
+    configured_provider = model_config.get("provider", "openai")
+    if configured_provider not in provider_options:
+        provider_options.append(configured_provider)
+    provider = st.selectbox(
+        "Provider",
+        provider_options,
+        index=provider_options.index(configured_provider),
+    )
+    configured_endpoint_url = (
+        str(model_config.get("base_url", "")).strip()
+        if provider == configured_provider and provider in {"openai", "azure_apim"}
+        else ""
+    )
+    trusted_endpoint_url = str(get_base_url(provider) or "").rstrip("/")
+    untrusted_custom_endpoint = bool(
+        configured_endpoint_url
+        and (
+            provider == "openai"
+            or not trusted_endpoint_url
+            or configured_endpoint_url.rstrip("/") != trusted_endpoint_url
+        )
+    )
+    provider_ready = bool(get_api_key(provider))
+    if provider == "azure_apim":
+        provider_ready = provider_ready and bool(get_base_url(provider))
+    if untrusted_custom_endpoint:
+        provider_ready = False
+        st.warning(
+            "Experiments against a user-supplied endpoint are disabled in the "
+            "public scaffolder so its central API key is never sent to that host. "
+            "The generated app will use the endpoint with your own key."
+        )
+    elif not provider_ready:
+        st.error(
+            f"The scaffolder host has no usable {provider} credentials. "
+            "Choose the provider configured by the scaffolder administrator."
+        )
+    configured_models = parse_model_names(
+        [
+            model_config.get("name", ""),
+            *parse_model_names(model_config.get("allowed_models", "")),
+        ]
+    )
+    configured_for_provider = (
+        configured_models if provider == model_config.get("provider") else []
+    )
+    if untrusted_custom_endpoint:
+        model_choices, choice_source, discovery = [], None, None
+    else:
+        model_choices, choice_source, discovery = get_endpoint_model_choices(
+            provider, configured_for_provider
+        )
+        render_endpoint_model_status(discovery, choice_source)
+    configured_model = str(model_config.get("name", "")).strip()
+    if model_choices:
+        default_models = (
+            [configured_model]
+            if configured_model in model_choices
+            else model_choices[:1]
+        )
+        model_names = st.multiselect(
+            "Models",
+            model_choices,
+            default=default_models,
+            help="Select one or more models to compare.",
+        )
+    else:
+        model_names = st.text_area(
+            "Models (one per line or comma-separated)",
+            value=configured_model,
+            help="Use model or deployment names accepted by the selected provider.",
+        )
+    question = st.text_area(
+        "Test question",
+        placeholder="What should a user know about…?",
+    )
+    top_k = st.slider("Retrieved passages per run", 1, 10, 5)
+
+    matrix = build_experiment_matrix(
+        profiles, prompt_keys, knowledgebase_keys, model_names
+    )
+    run_count = len(matrix)
+    if run_count:
+        st.caption(f"{run_count} model call{'s' if run_count != 1 else ''} will run.")
+    if run_count > 12:
+        st.error("Choose fewer options so the experiment has no more than 12 runs.")
+
+    can_run = bool(question.strip() and matrix and run_count <= 12 and provider_ready)
+    if st.button("Run experiment", type="primary", disabled=not can_run):
+        experiment_run_id = str(uuid.uuid4())
+        db_path = os.path.join(st.session_state.temp_data_dir, "app.sqlite3")
+        chroma_path = os.path.join(st.session_state.temp_data_dir, "chroma")
+        document_labels = get_scaffold_document_labels(db_path)
+        results = []
+
+        progress = st.progress(0, text="Starting experiment…")
+        for index, combination in enumerate(matrix):
+            prompt_profile = combination["prompt"]
+            knowledgebase_profile = combination["knowledgebase"]
+            model = combination["model"]
+            progress.progress(
+                index / run_count,
+                text=f"Running {prompt_profile['label']} × {knowledgebase_profile['label']} × {model}",
+            )
+            started = time.perf_counter()
+            context_chunks = []
+            answer = ""
+            error = None
+            failure_stage = None
+            try:
+                context_chunks = query_index(
+                    question,
+                    n_results=top_k,
+                    knowledgebase=knowledgebase_profile["knowledgebase"],
+                    connected_files=knowledgebase_profile.get("connected_files"),
+                    db_path=db_path,
+                    chroma_path=chroma_path,
+                )
+            except Exception as exc:
+                error = exc
+                failure_stage = "retrieval"
+
+            if error is None:
+                messages = build_experiment_messages(
+                    prompt_profile["prompt"], question, context_chunks
+                )
+                try:
+                    response = call_llm(
+                        messages,
+                        stream=False,
+                        model_override=model,
+                        provider_override=provider,
+                        enforce_model_allowlist=False,
+                    )
+                    answer = response_text(response)
+                    if not answer:
+                        error = RuntimeError("The model returned an empty response.")
+                        failure_stage = "response"
+                except Exception as exc:
+                    error = exc
+                    failure_stage = "completion"
+
+            elapsed = time.perf_counter() - started
+            input_tokens = (
+                estimate_tokens(question)
+                + estimate_tokens(prompt_profile["prompt"])
+                + sum(
+                    estimate_tokens(chunk.get("content", ""))
+                    for chunk in context_chunks
+                )
+            )
+            safe_error = log_ai_call_event(
+                run_id=experiment_run_id,
+                source="experiment_lab",
+                provider=provider,
+                model=model,
+                prompt_key=prompt_profile["key"],
+                knowledgebase=knowledgebase_profile["knowledgebase"],
+                status="failed" if error else "succeeded",
+                stage=failure_stage or "completion",
+                error=error,
+                latency_ms=round(elapsed * 1000),
+                tokens_in=input_tokens,
+                tokens_out=estimate_tokens(answer),
+            )
+
+            results.append(
+                {
+                    "run_id": experiment_run_id,
+                    "prompt_label": prompt_profile["label"],
+                    "knowledgebase_label": knowledgebase_profile["label"],
+                    "knowledgebase": knowledgebase_profile["knowledgebase"],
+                    "model": model,
+                    "provider": provider,
+                    "answer": answer,
+                    "error": safe_error,
+                    "failure_stage": failure_stage,
+                    "elapsed": elapsed,
+                    "tokens": estimate_tokens(question) + estimate_tokens(answer),
+                    "sources": [
+                        {
+                            "filename": document_labels.get(
+                                chunk.get("metadata", {}).get("document_id"),
+                                "Knowledge base document",
+                            ),
+                            "page": chunk.get("metadata", {}).get("page_number"),
+                            "content": chunk.get("content", ""),
+                        }
+                        for chunk in context_chunks
+                    ],
+                }
+            )
+        progress.progress(1.0, text="Experiment complete")
+        st.session_state.experiment_results = results
+        st.session_state.experiment_question = question
+
+    results = st.session_state.get("experiment_results", [])
+    if results:
+        st.subheader("Results")
+        st.caption(f"Question: {st.session_state.get('experiment_question', question)}")
+        columns = st.columns(min(3, len(results)))
+        for index, result in enumerate(results):
+            with columns[index % len(columns)]:
+                st.markdown(
+                    f"#### {result['prompt_label']} × {result['knowledgebase_label']}"
+                )
+                st.caption(
+                    f"{result['model']} via {result['provider']} · "
+                    f"{result['elapsed']:.1f}s · ~{result['tokens']} tokens · "
+                    f"run {result['run_id'][:8]}"
+                )
+                if result["error"]:
+                    st.error(
+                        f"{result['failure_stage'].title()} failed: {result['error']}"
+                    )
+                else:
+                    st.markdown(result["answer"])
+                with st.expander(f"Retrieved sources ({len(result['sources'])})"):
+                    if not result["sources"]:
+                        st.write("No matching passages were retrieved.")
+                    for source_index, source in enumerate(result["sources"]):
+                        page = source["page"] if source["page"] is not None else "N/A"
+                        st.markdown(
+                            f"**Source {source_index + 1}: {source['filename']}, page {page}**"
+                        )
+                        st.write(source["content"])
+                        st.divider()
+
+
 def main():
     # Branding: Apply to Scaffolder itself
     logo_url = get_secret_value(
@@ -241,10 +763,18 @@ def main():
                 }
             ],
         }
+    ensure_model_defaults(st.session_state.app_config)
 
     # Sidebar Navigation
     step = st.sidebar.radio(
-        "Steps", ["1. Identity", "2. AI Model", "3. Knowledge", "4. Export"]
+        "Steps",
+        [
+            "1. Identity",
+            "2. AI Model",
+            "3. Knowledge",
+            "4. Experiment Lab",
+            "5. Export",
+        ],
     )
 
     if step == "1. Identity":
@@ -273,15 +803,29 @@ def main():
         )
 
         if st.session_state.app_config["app"]["access_mode"] == "password":
-            st.info(
-                "Since you chose 'Password Protected', you will need to set a SHA-256 password hash in your secrets later. We will help you generate this in the final step."
+            render_password_hash_setup(
+                "App access password",
+                "scaffold_shared_password_hash",
+                "Choose the password visitors will use. AskLit immediately hashes it "
+                "and does not retain the plain-text password.",
             )
+        else:
+            st.session_state.pop("scaffold_shared_password_hash", None)
 
         st.session_state.app_config["app"]["disable_admin"] = st.checkbox(
             "Disable Admin Backend",
             st.session_state.app_config["app"].get("disable_admin", False),
             help="Hide all management and setup pages in the deployed app.",
         )
+        if not st.session_state.app_config["app"]["disable_admin"]:
+            render_password_hash_setup(
+                "Administrator password",
+                "scaffold_admin_password_hash",
+                "Choose a separate password for the hidden administration pages. "
+                "Only its hash will be placed in deployment secrets.",
+            )
+        else:
+            st.session_state.pop("scaffold_admin_password_hash", None)
 
         st.subheader("Prompt & Knowledge Base Pairings")
         st.session_state.app_config["prompt_profiles"] = normalize_prompt_profiles(
@@ -375,9 +919,9 @@ def main():
             logo_path = os.path.join(assets_dir, logo_file.name)
             with open(logo_path, "wb") as f:
                 f.write(logo_file.getbuffer())
-            st.session_state.app_config["branding"][
-                "logo_url"
-            ] = f"data/assets/{logo_file.name}"
+            st.session_state.app_config["branding"]["logo_url"] = (
+                f"data/assets/{logo_file.name}"
+            )
             st.success(f"Logo uploaded: {logo_file.name}")
         else:
             st.session_state.app_config["branding"]["logo_url"] = st.text_input(
@@ -394,9 +938,9 @@ def main():
             fav_path = os.path.join(assets_dir, favicon_file.name)
             with open(fav_path, "wb") as f:
                 f.write(favicon_file.getbuffer())
-            st.session_state.app_config["branding"][
-                "favicon_url"
-            ] = f"data/assets/{favicon_file.name}"
+            st.session_state.app_config["branding"]["favicon_url"] = (
+                f"data/assets/{favicon_file.name}"
+            )
             st.success(f"Favicon uploaded: {favicon_file.name}")
         else:
             st.session_state.app_config["branding"]["favicon_url"] = st.text_input(
@@ -423,31 +967,154 @@ def main():
     elif step == "2. AI Model":
         st.header("Step 2: AI Configuration")
         st.info(
-            "You won't need to provide API keys here. You'll set them later in your GitHub/Streamlit settings."
+            "You won't provide API keys here. The scaffolder's own credentials are "
+            "never exported; add your key later in the generated app's private "
+            "Streamlit settings."
         )
 
+        previous_provider = st.session_state.app_config["model"].get(
+            "provider", "openai"
+        )
         provider = st.selectbox(
             "LLM Provider",
             ["openai", "azure_apim", "anthropic", "google", "groq", "mistral"],
+            index=[
+                "openai",
+                "azure_apim",
+                "anthropic",
+                "google",
+                "groq",
+                "mistral",
+            ].index(previous_provider),
             help="Azure APIM uses a limited gateway credential instead of exposing a Foundry account key.",
         )
-        model_name = st.text_input(
-            "Model Name",
-            value=st.session_state.app_config["model"].get(
-                "name", "gpt-4o" if provider == "openai" else ""
-            ),
+        current_model = st.session_state.app_config["model"].get(
+            "name", "gpt-5.4-mini" if provider == "openai" else ""
         )
+        current_allowed_models = st.session_state.app_config["model"].get(
+            "allowed_models", ""
+        )
+        current_base_url = (
+            st.session_state.app_config["model"].get("base_url", "")
+            if provider == previous_provider
+            else ""
+        )
+        custom_openai_endpoint = False
+        custom_apim_endpoint = False
+        model_base_url = ""
+        endpoint_error = None
+        if provider == "openai":
+            custom_openai_endpoint = st.checkbox(
+                "Use a custom OpenAI-compatible endpoint",
+                value=bool(current_base_url),
+                help=(
+                    "Examples include an OpenAI-compatible proxy or Azure's "
+                    "/openai/v1 endpoint. The generated app will use your own API key."
+                ),
+            )
+            if custom_openai_endpoint:
+                entered_base_url = st.text_input(
+                    "OpenAI-compatible base URL",
+                    value=current_base_url,
+                    placeholder="https://example.com/v1",
+                )
+                model_base_url, endpoint_error = normalize_openai_base_url(
+                    entered_base_url
+                )
+                if endpoint_error:
+                    st.error(endpoint_error)
+                elif model_base_url.startswith("http://"):
+                    st.warning(
+                        "Use HTTPS for a remotely hosted app. HTTP should be limited "
+                        "to local development endpoints."
+                    )
+                st.caption(
+                    "For safety, this public scaffolder does not send its API key to "
+                    "custom endpoints. Enter the model name manually; the exported app "
+                    "will use this URL with the API key you add to its secrets."
+                )
+        elif provider == "azure_apim":
+            trusted_gateway_url = str(get_base_url("azure_apim") or "").rstrip("/")
+            entered_gateway_url = st.text_input(
+                "Azure APIM gateway base URL",
+                value=current_base_url or trusted_gateway_url,
+                placeholder="https://your-gateway.azure-api.net/asklit",
+                help=(
+                    "The current workshop gateway is prefilled. Change it only when "
+                    "the generated app should use a different APIM gateway."
+                ),
+            )
+            model_base_url, endpoint_error = normalize_openai_base_url(
+                entered_gateway_url
+            )
+            custom_apim_endpoint = bool(
+                entered_gateway_url
+                and (
+                    endpoint_error
+                    or not trusted_gateway_url
+                    or model_base_url.rstrip("/") != trusted_gateway_url
+                )
+            )
+            if endpoint_error:
+                st.error(endpoint_error)
+            elif custom_apim_endpoint:
+                st.caption(
+                    "This URL will be exported, but the scaffolder will not send its "
+                    "gateway key to an untrusted custom gateway. Enter deployment "
+                    "names manually."
+                )
+            else:
+                st.caption("Using the scaffolder's current default APIM gateway URL.")
+
+        configured_for_provider = (
+            [current_model, *parse_model_names(current_allowed_models)]
+            if provider == previous_provider
+            else []
+        )
+        manual_custom_endpoint = custom_openai_endpoint or custom_apim_endpoint
+        if manual_custom_endpoint:
+            model_choices, choice_source, discovery = [], None, None
+        else:
+            model_choices, choice_source, discovery = get_endpoint_model_choices(
+                provider,
+                configured_for_provider,
+                base_url_override=(
+                    model_base_url if provider == "azure_apim" else None
+                ),
+            )
+            render_endpoint_model_status(discovery, choice_source)
+
+        if manual_custom_endpoint:
+            model_name = st.text_input("Model Name", value=current_model)
+        elif model_choices:
+            selected_index = (
+                model_choices.index(current_model)
+                if current_model in model_choices
+                else 0
+            )
+            model_name = st.selectbox(
+                "Model Name",
+                model_choices,
+                index=selected_index,
+            )
+        else:
+            model_name = st.text_input("Model Name", value=current_model)
 
         allow_user_selection = False
-        allowed_models = ""
+        allowed_models = current_allowed_models
         if provider == "azure_apim":
             allow_user_selection = st.checkbox(
                 "Let users choose among approved models",
-                value=True,
+                value=st.session_state.app_config["model"].get(
+                    "allow_user_selection", True
+                ),
             )
             allowed_models = st.text_area(
                 "Approved Azure deployment names",
-                value="gpt-5.4-nano,gpt-5.4-mini,gpt-5.6-sol,deepseek-v4-pro,grok-4.1-fast-reasoning,llama-4-maverick",
+                value=st.session_state.app_config["model"].get(
+                    "allowed_models",
+                    "gpt-5.4-nano,gpt-5.4-mini,gpt-5.6-sol,deepseek-v4-pro,grok-4.1-fast-reasoning,llama-4-maverick,kimi-k2.6,mistral-large-3,phi-4-mini,gpt-4.1-nano,gpt-4.1-mini",
+                ),
                 help="Comma-separated. Keep this synchronized with the APIM policy allowlist.",
             )
 
@@ -456,6 +1123,7 @@ def main():
             "name": model_name,
             "allow_user_selection": allow_user_selection,
             "allowed_models": allowed_models,
+            "base_url": model_base_url,
             "use_local_embeddings": True,
             "local_embedding_model": "all-MiniLM-L6-v2",
         }
@@ -557,57 +1225,87 @@ def main():
 
                     st.success(f"Indexed {len(uploaded_files)} documents!")
 
-    elif step == "4. Export":
-        st.header("Step 4: Export your Project")
+    elif step == "4. Experiment Lab":
+        render_experiment_lab()
+
+    elif step == "5. Export":
+        ensure_model_defaults(st.session_state.app_config)
+        st.header("Step 5: Export your Project")
 
         # 1. Configuration Generator
-        with st.expander("📋 Deployment Secrets (Copy this!)", expanded=True):
+        with st.expander("📋 Deployment Settings & Secrets", expanded=True):
             st.markdown(
                 "Paste the following into your **Streamlit Cloud > Settings > Secrets** panel:"
             )
 
-            # Generate the secrets TOML
-            secrets_toml = f"# AskLit Deployment Secrets\n"
-            secrets_toml += f"{st.session_state.app_config['model']['provider'].upper()}_API_KEY = \"PASTE_YOUR_KEY_HERE\"\n\n"
-            if st.session_state.app_config["model"]["provider"] == "azure_apim":
-                secrets_toml += 'AZURE_APIM_BASE_URL = "https://YOUR-GATEWAY.azure-api.net/asklit"\n\n'
-                secrets_toml += '"limits.max_output_tokens_hard" = "4000"\n'
-                secrets_toml += '"limits.max_conversation_turns" = "30"\n\n'
+            password_hashes = {
+                "shared": st.session_state.get("scaffold_shared_password_hash"),
+                "admin": st.session_state.get("scaffold_admin_password_hash"),
+            }
+            secrets_toml = generate_deployment_secrets(
+                st.session_state.app_config,
+                password_hashes=password_hashes,
+            )
 
-            secrets_toml += f"# Identity & Access\n"
-            secrets_toml += 'ADMIN_ROUTE = "manage"\n'
-            if not st.session_state.app_config["app"].get("disable_admin"):
-                secrets_toml += 'ADMIN_PASSWORD_HASH = "PASTE_ADMIN_HASH_HERE"\n'
-
-            if st.session_state.app_config["app"]["access_mode"] == "password":
-                secrets_toml += 'SHARED_PASSWORD_HASH = "PASTE_SHARED_HASH_HERE"\n'
-
-            secrets_toml += "\n# App Overrides\n"
-            secrets_toml += f"\"app.title\" = {toml_quote(st.session_state.app_config['app']['title'])}\n"
-            secrets_toml += f"\"app.access_mode\" = {toml_quote(st.session_state.app_config['app']['access_mode'])}\n"
-            secrets_toml += f"\"app.disable_admin\" = {str(st.session_state.app_config['app'].get('disable_admin', False)).lower()}\n"
+            missing_passwords = []
+            if (
+                st.session_state.app_config["app"]["access_mode"] == "password"
+                and not password_hashes["shared"]
+            ):
+                missing_passwords.append("app access password")
+            if (
+                not st.session_state.app_config["app"].get("disable_admin")
+                and not password_hashes["admin"]
+            ):
+                missing_passwords.append("administrator password")
+            if missing_passwords:
+                st.warning(
+                    "Return to Identity and configure: "
+                    + ", ".join(missing_passwords)
+                    + "."
+                )
 
             st.code(secrets_toml, language="toml")
-
-            if st.session_state.app_config["app"][
-                "access_mode"
-            ] == "password" or not st.session_state.app_config["app"].get(
-                "disable_admin"
-            ):
-                st.subheader("🔑 Password Hasher")
-                st.write("Need a hash? Type a password here and copy the result:")
-                raw_pwd = st.text_input(
-                    "Raw Password", type="password", key="scaffold_hasher"
-                )
-                if raw_pwd:
-                    from asklit.auth import hash_password
-
-                    h = hash_password(raw_pwd)
-                    st.code(h)
-                    st.caption("Copy this hash into your secrets above.")
+            st.download_button(
+                "Download deployment secrets",
+                data=secrets_toml,
+                file_name="asklit-deployment-secrets.toml",
+                mime="text/plain",
+                help=(
+                    "This contains password hashes and an API-key placeholder. "
+                    "Keep it out of GitHub."
+                ),
+            )
 
         st.divider()
+        st.subheader("Your no-code deployment checklist")
+        st.markdown(
+            """
+1. Click **Connect to GitHub** below and approve AskLit.
+2. Create the repository and wait for **Finished publishing files.**
+3. Open [Streamlit Community Cloud](https://share.streamlit.io/) and sign in with the same GitHub account.
+4. Click **Create app**, choose the new repository, branch **main**, and file **app.py**.
+5. In **Advanced settings**, paste your real configuration into **Secrets**, then click **Deploy**.
+
+Never upload `secrets.toml` to GitHub. Streamlit's **Secrets** box is the only place for real keys.
+"""
+        )
         repo_name = st.text_input("Repository Name", DEFAULT_REPO_NAME)
+        private_repo = st.checkbox(
+            "Make the GitHub repository private",
+            value=False,
+            help=(
+                "Public repositories work with Streamlit Community Cloud's free "
+                "deployment path. Choose private only if your hosting account can "
+                "access private repositories."
+            ),
+        )
+        if not private_repo:
+            st.warning(
+                "This repository will be public. Its generated configuration and "
+                "knowledge-base documents will be visible to everyone. Do not publish "
+                "confidential, student, client, or secret material."
+            )
 
         col1, col2 = st.columns(2)
 
@@ -635,157 +1333,133 @@ def main():
         with col2:
             st.subheader("Option B: Push to GitHub")
 
-            # OAuth Configuration from secrets
             client_id = get_secret_value("GITHUB_CLIENT_ID", None)
-            client_secret = get_secret_value("GITHUB_CLIENT_SECRET", None)
 
-            if not client_id or not client_secret:
-                st.warning(
-                    "GitHub OAuth is not configured. Please set GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET in secrets."
+            if not client_id:
+                st.error(
+                    "The centralized GitHub connection is temporarily unavailable. "
+                    "Please contact the AskLit administrator; you should never need to create a personal access token."
                 )
-                github_token = st.text_input(
-                    "Fallback: GitHub Personal Access Token", type="password"
-                )
+                github_token = None
             else:
-                # 1. Check if we already have a token
-                if "github_oauth_token" not in st.session_state:
-                    # Check if we are returning from GitHub with a code
-                    if "code" in st.query_params:
-                        with st.spinner("Authenticating with GitHub..."):
-                            code = st.query_params["code"]
-                            res = requests.post(
-                                "https://github.com/login/oauth/access_token",
-                                headers={"Accept": "application/json"},
-                                data={
-                                    "client_id": client_id,
-                                    "client_secret": client_secret,
-                                    "code": code,
-                                },
+                github_token = st.session_state.get("github_oauth_token")
+                device = st.session_state.get("github_oauth_device")
+
+                if device and time.time() >= device["expires_at"]:
+                    del st.session_state.github_oauth_device
+                    device = None
+                    st.warning("The GitHub connection code expired. Start again below.")
+
+                if not github_token and not device:
+                    if st.button("🔗 Connect to GitHub", type="primary"):
+                        try:
+                            device = request_device_code(
+                                client_id, timeout=REQUEST_TIMEOUT_SECONDS
+                            )
+                            device["expires_at"] = time.time() + int(
+                                device["expires_in"]
+                            )
+                            st.session_state.github_oauth_device = device
+                            st.rerun()
+                        except GitHubError as exc:
+                            st.error(str(exc))
+
+                if not github_token and device:
+                    st.info(
+                        "Open GitHub, enter the one-time code below, and approve "
+                        "private-repository access. Keep this page open."
+                    )
+                    st.code(device["user_code"], language=None)
+                    st.link_button(
+                        "Open GitHub authorization",
+                        device["verification_uri"],
+                        type="primary",
+                    )
+                    if st.button("I've authorized GitHub — connect"):
+                        try:
+                            result = poll_device_token(
+                                client_id,
+                                device["device_code"],
                                 timeout=REQUEST_TIMEOUT_SECONDS,
                             )
-                            if res.status_code == 200:
-                                token_data = res.json()
-                                if "access_token" in token_data:
-                                    st.session_state.github_oauth_token = token_data[
-                                        "access_token"
-                                    ]
-                                    # Clear code from URL to keep it clean
-                                    st.query_params.clear()
-                                    st.rerun()
-                                else:
-                                    st.error(
-                                        f"OAuth Error: {token_data.get('error_description', 'Unknown error')}"
-                                    )
+                            if result["status"] == "complete":
+                                st.session_state.github_oauth_token = result[
+                                    "access_token"
+                                ]
+                                st.session_state.pop("github_oauth_device", None)
+                                st.rerun()
+                            elif result["status"] == "pending":
+                                st.info(
+                                    "GitHub has not received the approval yet. "
+                                    "Approve it there, then try this button again."
+                                )
                             else:
-                                st.error("Failed to exchange code for token.")
+                                st.session_state.pop("github_oauth_device", None)
+                                st.error(result["message"])
+                        except GitHubError as exc:
+                            st.error(str(exc))
 
-                    # Show Connect Button
-                    redirect_uri = get_secret_value("GITHUB_REDIRECT_URI", None)
-                    auth_url = (
-                        f"https://github.com/login/oauth/authorize?client_id={client_id}&scope=repo&redirect_uri={redirect_uri}"
-                        if redirect_uri
-                        else f"https://github.com/login/oauth/authorize?client_id={client_id}&scope=repo"
-                    )
-
-                    st.link_button("🔗 Connect to GitHub", auth_url, type="primary")
-                    github_token = None
-                else:
-                    st.success("Connected to GitHub!")
-                    if st.button("Disconnect"):
-                        del st.session_state.github_oauth_token
+                if github_token:
+                    try:
+                        github_user = st.session_state.get("github_oauth_user")
+                        if not github_user:
+                            github_user = get_authenticated_user(
+                                github_token, timeout=REQUEST_TIMEOUT_SECONDS
+                            )
+                            st.session_state.github_oauth_user = github_user
+                        st.success(f"Connected to GitHub as {github_user['login']}.")
+                    except GitHubError as exc:
+                        st.session_state.pop("github_oauth_token", None)
+                        st.session_state.pop("github_oauth_user", None)
+                        github_token = None
+                        st.error(str(exc))
+                    if github_token and st.button("Disconnect GitHub"):
+                        st.session_state.pop("github_oauth_token", None)
+                        st.session_state.pop("github_oauth_user", None)
                         st.rerun()
-                    github_token = st.session_state.github_oauth_token
 
             if github_token:
                 if st.button("🚀 Create Repo & Push"):
                     with st.spinner("Creating repository..."):
-                        # 1. Create Repo
-                        headers = {
-                            "Authorization": f"token {github_token}",
-                            "Accept": "application/vnd.github.v3+json",
-                        }
-                        user_res = requests.get(
-                            "https://api.github.com/user",
-                            headers=headers,
-                            timeout=REQUEST_TIMEOUT_SECONDS,
+                        bundle_dir = create_bundle(
+                            st.session_state.app_config,
+                            st.session_state.temp_data_dir,
                         )
-                        if user_res.status_code != 200:
-                            st.error("Invalid GitHub Token")
-                        else:
-                            username = user_res.json()["login"]
-                            repo_res = requests.post(
-                                "https://api.github.com/user/repos",
-                                headers=headers,
-                                json={"name": repo_name, "private": True},
-                                timeout=REQUEST_TIMEOUT_SECONDS,
+                        publish_progress = st.progress(0.0, text="Preparing files...")
+
+                        def update_publish_progress(completed, total, path):
+                            publish_progress.progress(
+                                completed / total,
+                                text=f"Publishing {path} ({completed}/{total})",
                             )
 
-                            if repo_res.status_code == 201:
-                                st.success(
-                                    f"Created repository: {username}/{repo_name}"
-                                )
-                                st.info(
-                                    "Pushing files via API... (This may take a moment)"
-                                )
-
-                                # 2. Push files (Simplified: using the ZIP approach or individual commits)
-                                # Note: Pushing large binary files (like the DB) via the Content API has limits (20MB).
-                                # For a better experience, we should tell them to use the ZIP for now if it fails.
-                                st.warning(
-                                    "Direct push via API is limited for large knowledge bases. If it fails, use the ZIP option."
-                                )
-
-                                bundle_dir = create_bundle(
-                                    st.session_state.app_config,
-                                    st.session_state.temp_data_dir,
-                                )
-
-                                # Recursive function to push files
-                                def push_files(
-                                    dir_path,
-                                    repo_full_name,
-                                    branch="main",
-                                    base_path="",
-                                ):
-                                    for item in os.listdir(dir_path):
-                                        full_path = os.path.join(dir_path, item)
-                                        git_path = os.path.join(base_path, item)
-
-                                        if os.path.isdir(full_path):
-                                            push_files(
-                                                full_path,
-                                                repo_full_name,
-                                                branch,
-                                                git_path,
-                                            )
-                                        else:
-                                            with open(full_path, "rb") as f:
-                                                import base64
-
-                                                content = base64.b64encode(
-                                                    f.read()
-                                                ).decode()
-
-                                            # Put file
-                                            put_res = requests.put(
-                                                f"https://api.github.com/repos/{repo_full_name}/contents/{git_path}",
-                                                headers=headers,
-                                                json={
-                                                    "message": f"Add {git_path}",
-                                                    "content": content,
-                                                    "branch": branch,
-                                                },
-                                                timeout=REQUEST_TIMEOUT_SECONDS,
-                                            )
-                                            if put_res.status_code not in [200, 201]:
-                                                st.error(
-                                                    f"Failed to push {git_path}: {put_res.text}"
-                                                )
-
-                                push_files(bundle_dir, f"{username}/{repo_name}")
-                                st.success("Finished pushing files!")
-                            else:
-                                st.error(f"Failed to create repo: {repo_res.text}")
+                        try:
+                            result = publish_directory(
+                                github_token,
+                                repo_name,
+                                bundle_dir,
+                                private=private_repo,
+                                timeout=REQUEST_TIMEOUT_SECONDS,
+                                progress=update_publish_progress,
+                            )
+                            publish_progress.progress(
+                                1.0, text="Finished publishing files."
+                            )
+                            st.success(
+                                f"Published {result['files_published']} files to "
+                                f"{result['full_name']}."
+                            )
+                            st.link_button(
+                                "Open the new GitHub repository",
+                                result["html_url"],
+                                type="primary",
+                            )
+                        except GitHubError as exc:
+                            st.error(str(exc))
+                            st.caption(
+                                "If GitHub created the repository before an upload "
+                                "failed, open GitHub to review or delete the partial repository."
+                            )
 
 
 if __name__ == "__main__":

--- a/scripts/start-container.sh
+++ b/scripts/start-container.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+mkdir -p /app/data
+if [ ! -f /app/data/app.sqlite3 ]; then
+  cp -a /opt/asklit-seed-data/. /app/data/
+fi
+
+exec streamlit run app.py \
+  --server.port=8501 \
+  --server.address=0.0.0.0 \
+  --server.headless=true

--- a/test_core_quality.py
+++ b/test_core_quality.py
@@ -2,7 +2,7 @@ import sqlite3
 import unittest
 
 from asklit.auth import hash_password, verify_password
-from asklit.config import get_nested_value, get_setting
+from asklit.config import get_base_url, get_nested_value, get_setting
 from asklit.db import get_connection, init_db
 from asklit.prompts import load_prompt_configs, save_new_prompt, get_active_prompt
 from asklit.ui import escape_html, safe_url
@@ -32,6 +32,7 @@ def test_init_db_creates_parent_directory_and_tables(tmp_path):
     case.assertIn("settings", tables)
     case.assertIn("documents", tables)
     case.assertIn("messages", tables)
+    case.assertIn("ai_call_events", tables)
     case.assertIn("knowledgebase", columns)
     case.assertIn("prompt_key", prompt_columns)
 
@@ -164,6 +165,17 @@ def test_settings_fall_back_to_environment(monkeypatch, tmp_path):
     monkeypatch.setenv("APP_TITLE", "Env Title")
 
     case.assertEqual(get_setting("app.title", "Default"), "Env Title")
+
+
+def test_openai_base_url_falls_back_to_generated_model_config(monkeypatch, tmp_path):
+    case = unittest.TestCase()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("ASKLIT_DB_PATH", str(tmp_path / "missing" / "app.sqlite3"))
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("MODEL_BASE_URL", "https://models.example/v1")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    case.assertEqual(get_base_url("openai"), "https://models.example/v1")
 
 
 def test_get_nested_value_supports_dotted_keys():

--- a/test_experiments.py
+++ b/test_experiments.py
@@ -1,0 +1,67 @@
+from types import SimpleNamespace
+
+from asklit.experiments import (
+    build_experiment_matrix,
+    build_experiment_messages,
+    parse_model_names,
+    response_text,
+)
+
+
+PROFILES = [
+    {
+        "key": "housing",
+        "label": "Housing",
+        "knowledgebase": "housing-kb",
+        "prompt": "Housing prompt",
+        "connected_files": [],
+    },
+    {
+        "key": "benefits",
+        "label": "Benefits",
+        "knowledgebase": "benefits-kb",
+        "prompt": "Benefits prompt",
+        "connected_files": [],
+    },
+]
+
+
+def test_experiment_matrix_builds_cartesian_product():
+    matrix = build_experiment_matrix(
+        PROFILES,
+        ["housing", "benefits"],
+        ["benefits"],
+        "model-a, model-b",
+    )
+
+    assert len(matrix) == 4
+    assert {item["prompt"]["key"] for item in matrix} == {"housing", "benefits"}
+    assert {item["knowledgebase"]["key"] for item in matrix} == {"benefits"}
+    assert {item["model"] for item in matrix} == {"model-a", "model-b"}
+
+
+def test_model_names_are_trimmed_and_deduplicated():
+    assert parse_model_names("model-a\nmodel-b, model-a") == ["model-a", "model-b"]
+
+
+def test_experiment_messages_use_selected_prompt_and_context():
+    messages = build_experiment_messages(
+        "Selected prompt",
+        "What are my rights?",
+        [{"content": "A" * 100}],
+    )
+
+    assert messages[0]["role"] == "system"
+    assert "Selected prompt" in messages[0]["content"]
+    assert "A" * 100 in messages[0]["content"]
+    assert messages[1] == {"role": "user", "content": "What are my rights?"}
+
+
+def test_response_text_supports_object_and_dict_responses():
+    object_response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="Object answer"))]
+    )
+    dict_response = {"choices": [{"message": {"content": "Dict answer"}}]}
+
+    assert response_text(object_response) == "Object answer"
+    assert response_text(dict_response) == "Dict answer"

--- a/test_github.py
+++ b/test_github.py
@@ -1,0 +1,147 @@
+import pytest
+
+from asklit import github
+
+
+class Response:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class DeviceHttp:
+    def __init__(self, payload):
+        self.payload = payload
+        self.calls = []
+
+    def post(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return Response(200, self.payload)
+
+
+def test_device_flow_requests_repo_scope():
+    http = DeviceHttp(
+        {
+            "device_code": "device-secret",
+            "user_code": "ABCD-EFGH",
+            "verification_uri": "https://github.com/login/device",
+            "expires_in": 900,
+            "interval": 5,
+        }
+    )
+
+    result = github.request_device_code("client-id", http=http)
+
+    assert result["user_code"] == "ABCD-EFGH"
+    assert http.calls[0][1]["data"] == {"client_id": "client-id", "scope": "repo"}
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"error": "authorization_pending"}, "pending"),
+        ({"access_token": "user-token", "token_type": "bearer"}, "complete"),
+        ({"error": "access_denied"}, "denied"),
+        ({"error": "expired_token"}, "expired"),
+    ],
+)
+def test_poll_device_token_reports_safe_status(payload, expected):
+    result = github.poll_device_token(
+        "client-id", "device-code", http=DeviceHttp(payload)
+    )
+    assert result["status"] == expected
+
+
+class PublishHttp:
+    def __init__(self):
+        self.posts = []
+        self.puts = []
+
+    def post(self, url, **kwargs):
+        self.posts.append((url, kwargs))
+        return Response(
+            201,
+            {
+                "full_name": "professor/demo",
+                "default_branch": "main",
+                "html_url": "https://github.com/professor/demo",
+            },
+        )
+
+    def put(self, url, **kwargs):
+        self.puts.append((url, kwargs))
+        return Response(201, {"content": {"path": url.rsplit("/", 1)[-1]}})
+
+
+def test_publish_initializes_empty_repo_then_uses_default_branch(tmp_path):
+    (tmp_path / "README.md").write_text("# Demo\n", encoding="utf-8")
+    (tmp_path / "app.py").write_text("print('ok')\n", encoding="utf-8")
+    http = PublishHttp()
+    progress = []
+
+    result = github.publish_directory(
+        "oauth-token",
+        "demo",
+        tmp_path,
+        http=http,
+        progress=lambda done, total, path: progress.append((done, total, path)),
+    )
+
+    assert result == {
+        "full_name": "professor/demo",
+        "html_url": "https://github.com/professor/demo",
+        "files_published": 2,
+    }
+    assert http.posts[0][1]["json"] == {
+        "name": "demo",
+        "private": False,
+        "auto_init": False,
+    }
+    assert "branch" not in http.puts[0][1]["json"]
+    assert http.puts[0][0].endswith("/contents/README.md")
+    assert http.puts[1][1]["json"]["branch"] == "main"
+    assert http.puts[1][1]["headers"]["Authorization"] == "Bearer oauth-token"
+    assert progress[-1] == (2, 2, "app.py")
+
+
+def test_publish_preflights_large_files_before_creating_repo(monkeypatch, tmp_path):
+    monkeypatch.setattr(github, "MAX_CONTENT_API_FILE_BYTES", 3)
+    (tmp_path / "large.pdf").write_bytes(b"four")
+    http = PublishHttp()
+
+    with pytest.raises(github.GitHubError, match="20 MB"):
+        github.publish_directory("token", "demo", tmp_path, http=http)
+
+    assert http.posts == []
+
+
+def test_publish_omits_nested_python_and_tool_caches(tmp_path):
+    (tmp_path / "README.md").write_text("# Demo\n", encoding="utf-8")
+    (tmp_path / "asklit").mkdir()
+    (tmp_path / "asklit" / "app.py").write_text("pass\n", encoding="utf-8")
+    (tmp_path / "asklit" / "__pycache__").mkdir()
+    (tmp_path / "asklit" / "__pycache__" / "app.pyc").write_bytes(b"cache")
+    (tmp_path / ".pytest_cache").mkdir()
+    (tmp_path / ".pytest_cache" / "state").write_text("cache", encoding="utf-8")
+    http = PublishHttp()
+
+    result = github.publish_directory("token", "demo", tmp_path, http=http)
+
+    published_urls = [url for url, _kwargs in http.puts]
+    assert result["files_published"] == 2
+    assert any(url.endswith("/contents/README.md") for url in published_urls)
+    assert any(url.endswith("/contents/asklit/app.py") for url in published_urls)
+    assert not any("__pycache__" in url for url in published_urls)
+    assert not any(".pytest_cache" in url for url in published_urls)
+
+
+def test_publish_can_explicitly_create_a_private_repository(tmp_path):
+    (tmp_path / "README.md").write_text("# Private\n", encoding="utf-8")
+    http = PublishHttp()
+
+    github.publish_directory("token", "private-demo", tmp_path, private=True, http=http)
+
+    assert http.posts[0][1]["json"]["private"] is True

--- a/test_models.py
+++ b/test_models.py
@@ -1,0 +1,91 @@
+from asklit.models import (
+    choose_model_options,
+    describe_openai_compatible_endpoint,
+    discover_available_models,
+    normalize_openai_base_url,
+)
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self.payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.payload
+
+
+def test_openai_alias_identifies_azure_compatible_endpoint():
+    label = describe_openai_compatible_endpoint(
+        "openai",
+        "https://example.cognitiveservices.azure.com/openai/v1/",
+    )
+
+    assert label == "Azure AI (OpenAI-compatible)"
+
+
+def test_small_compatible_model_list_is_available_for_selection(monkeypatch):
+    captured = {}
+
+    def fake_get(url, headers, timeout):
+        captured.update(url=url, headers=headers, timeout=timeout)
+        return FakeResponse({"data": [{"id": "model-b"}, {"id": "model-a"}]})
+
+    monkeypatch.setattr("asklit.models.requests.get", fake_get)
+    discovery = discover_available_models(
+        "openai", "https://models.example/v1/", "secret", timeout=3
+    )
+    choices, source = choose_model_options(discovery, [])
+
+    assert captured["url"] == "https://models.example/v1/models"
+    assert captured["headers"]["Authorization"] == "Bearer secret"
+    assert discovery["models"] == ["model-a", "model-b"]
+    assert choices == ["model-a", "model-b"]
+    assert source == "endpoint model list"
+
+
+def test_azure_catalog_is_not_presented_as_deployed_models():
+    discovery = {
+        "is_azure": True,
+        "models": [f"catalog-{index}" for index in range(334)],
+    }
+
+    choices, source = choose_model_options(
+        discovery,
+        ["gpt-5.4-mini", "llama-4-maverick"],
+    )
+
+    assert choices == ["gpt-5.4-mini", "llama-4-maverick"]
+    assert source == "configured Azure deployment allowlist"
+
+
+def test_large_non_azure_catalog_uses_manual_entry_without_configuration():
+    discovery = {
+        "is_azure": False,
+        "models": [f"model-{index}" for index in range(21)],
+    }
+
+    assert choose_model_options(discovery, []) == ([], None)
+
+
+def test_custom_openai_base_url_is_normalized_and_rejects_embedded_credentials():
+    assert normalize_openai_base_url(" https://models.example/v1/ ") == (
+        "https://models.example/v1",
+        None,
+    )
+    normalized, error = normalize_openai_base_url(
+        "https://user:password@models.example/v1"
+    )
+    assert normalized == ""
+    assert "credentials" in error
+
+
+def test_custom_openai_base_url_rejects_query_parameters():
+    normalized, error = normalize_openai_base_url(
+        "https://models.example/v1?api_key=secret"
+    )
+    assert normalized == ""
+    assert "query string" in error

--- a/test_observability.py
+++ b/test_observability.py
@@ -1,0 +1,44 @@
+from asklit.db import get_connection
+from asklit.observability import log_ai_call_event, safe_error_message
+
+
+def test_safe_error_message_redacts_credentials():
+    message = safe_error_message(
+        RuntimeError("Authorization: Bearer-secret API_KEY=sk-abcdefghijklmnop")
+    )
+
+    assert "Bearer-secret" not in message
+    assert "sk-abcdefghijklmnop" not in message
+    assert "[REDACTED]" in message
+
+
+def test_failed_ai_call_is_persisted(monkeypatch, tmp_path):
+    db_path = tmp_path / "app.sqlite3"
+    monkeypatch.setenv("ASKLIT_DB_PATH", str(db_path))
+
+    displayed_error = log_ai_call_event(
+        run_id="run-123",
+        source="experiment_lab",
+        provider="azure_apim",
+        model="gpt-5.4-mini",
+        prompt_key="housing",
+        knowledgebase="housing-kb",
+        status="failed",
+        stage="completion",
+        error=RuntimeError("Gateway returned 403"),
+        latency_ms=42,
+        tokens_in=100,
+        tokens_out=0,
+    )
+
+    conn = get_connection()
+    row = conn.execute(
+        "SELECT * FROM ai_call_events WHERE run_id = 'run-123'"
+    ).fetchone()
+    conn.close()
+
+    assert displayed_error == "Gateway returned 403"
+    assert row["status"] == "failed"
+    assert row["stage"] == "completion"
+    assert row["error_type"] == "RuntimeError"
+    assert row["error_message"] == "Gateway returned 403"

--- a/test_rag_scoping.py
+++ b/test_rag_scoping.py
@@ -55,3 +55,31 @@ def test_keyword_retrieval_is_scoped_by_knowledgebase_and_file(monkeypatch, tmp_
         "housing-b"
     ]
     assert resolve_document_filter("housing") == {"housing-a", "housing-b"}
+
+
+def test_keyword_retrieval_can_use_an_explicit_scaffold_database(tmp_path):
+    db_path = tmp_path / "scaffold" / "app.sqlite3"
+    init_db(str(db_path))
+    conn = get_connection(str(db_path))
+    conn.execute(
+        """
+        INSERT INTO documents
+            (id, knowledgebase, filename, file_path, file_type, file_size, status)
+        VALUES ('lab-doc', 'lab', 'lab.txt', 'data/uploads/lab.txt', '.txt', 20, 'indexed')
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO document_chunks
+            (document_id, chunk_index, content, page_number)
+        VALUES ('lab-doc', 0, 'experiment laboratory rights', 1)
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    results = query_keyword_index(
+        "laboratory rights", knowledgebase="lab", db_path=str(db_path)
+    )
+
+    assert [result["metadata"]["document_id"] for result in results] == ["lab-doc"]

--- a/test_scaffold_bundle.py
+++ b/test_scaffold_bundle.py
@@ -1,0 +1,190 @@
+from pathlib import Path
+
+import scaffold
+
+
+def test_production_runtime_entrypoint_has_no_scaffolder_page_reference():
+    runtime_app = Path(scaffold.__file__).parent / "runtime" / "app.py"
+
+    assert runtime_app.exists()
+    assert "scaffold.py" not in runtime_app.read_text(encoding="utf-8")
+
+
+def test_create_bundle_recursively_excludes_local_artifacts(monkeypatch, tmp_path):
+    source_root = tmp_path / "source"
+    source_root.mkdir()
+    for source_name in scaffold.RUNTIME_ROOT_FILES:
+        source_path = source_root / source_name
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_text(f"# {source_name}\n", encoding="utf-8")
+    admin = source_root / "admin"
+    admin.mkdir()
+    (admin / "settings.py").write_text("# admin\n", encoding="utf-8")
+    package = source_root / "asklit"
+    package.mkdir()
+    for filename in scaffold.RUNTIME_ASKLIT_MODULES:
+        (package / filename).write_text(f"# {filename}\n", encoding="utf-8")
+    (package / "github.py").write_text("# scaffolder only\n", encoding="utf-8")
+    (package / "experiments.py").write_text("# scaffolder only\n", encoding="utf-8")
+    (package / "models.py").write_text("# scaffolder only\n", encoding="utf-8")
+    (package / "__pycache__").mkdir()
+    (package / "__pycache__" / "config.pyc").write_bytes(b"compiled")
+    (source_root / ".pytest_cache").mkdir()
+    (source_root / ".pytest_cache" / "state").write_text("cache", encoding="utf-8")
+    (source_root / ".venv").mkdir()
+    (source_root / ".venv" / "python").write_text("binary", encoding="utf-8")
+    (source_root / "output").mkdir()
+    (source_root / "output" / "result.json").write_text("{}", encoding="utf-8")
+    (source_root / "tmp").mkdir()
+    (source_root / "tmp" / "debug.txt").write_text("debug", encoding="utf-8")
+    (source_root / "scaffold.py").write_text("# scaffolder\n", encoding="utf-8")
+    (source_root / "test_runtime.py").write_text("# test\n", encoding="utf-8")
+    (source_root / "Dockerfile").write_text("FROM python\n", encoding="utf-8")
+    (source_root / "fly.toml").write_text("app = 'wrong'\n", encoding="utf-8")
+    (source_root / ".env").write_text(
+        "OPENAI_API_KEY=host-key-must-not-export\n"
+        "AZURE_APIM_API_KEY=gateway-key-must-not-export\n",
+        encoding="utf-8",
+    )
+    (source_root / ".streamlit").mkdir()
+    (source_root / ".streamlit" / "secrets.toml").write_text(
+        'OPENAI_API_KEY = "host-key-must-not-export"\n'
+        'AZURE_APIM_API_KEY = "gateway-key-must-not-export"\n',
+        encoding="utf-8",
+    )
+    (source_root / "docs").mkdir()
+    (source_root / "docs" / "operator.md").write_text("docs", encoding="utf-8")
+
+    session_data = tmp_path / "session-data"
+    session_data.mkdir()
+    (session_data / "app.sqlite3").write_bytes(b"database")
+    monkeypatch.setattr(scaffold, "__file__", str(source_root / "scaffold.py"))
+
+    bundle = Path(
+        scaffold.create_bundle(
+            {
+                "app": {"title": "Generated App"},
+                "model": {
+                    "provider": "openai",
+                    "name": "custom-model",
+                    "base_url": "https://models.example/v1",
+                    "api_key": "host-key-must-not-export",
+                },
+                "prompt_profiles": [],
+            },
+            str(session_data),
+        )
+    )
+
+    assert (bundle / "app.py").exists()
+    assert (bundle / "chat_ui.py").exists()
+    assert (bundle / "admin" / "settings.py").exists()
+    assert (bundle / "asklit" / "config.py").exists()
+    assert (bundle / "data" / "app.sqlite3").exists()
+    assert (bundle / "prompts" / "default.yml").exists()
+    assert not list(bundle.rglob("__pycache__"))
+    assert not list(bundle.rglob("*.pyc"))
+    assert not (bundle / ".pytest_cache").exists()
+    assert not (bundle / ".venv").exists()
+    assert not (bundle / "output").exists()
+    assert not (bundle / "tmp").exists()
+    assert not (bundle / "scaffold.py").exists()
+    assert not (bundle / "test_runtime.py").exists()
+    assert not (bundle / "Dockerfile").exists()
+    assert not (bundle / "fly.toml").exists()
+    assert not (bundle / "docs").exists()
+    assert not (bundle / "asklit" / "github.py").exists()
+    assert not (bundle / "asklit" / "experiments.py").exists()
+    assert not (bundle / "asklit" / "models.py").exists()
+    assert {path.name for path in bundle.iterdir()} == {
+        ".gitignore",
+        ".streamlit",
+        "README.md",
+        "admin",
+        "app.py",
+        "asklit",
+        "chat_ui.py",
+        "config",
+        "data",
+        "login_ui.py",
+        "prompts",
+        "requirements.txt",
+    }
+    assert {path.name for path in (bundle / "asklit").iterdir()} == set(
+        scaffold.RUNTIME_ASKLIT_MODULES
+    )
+    assert "scaffold.py" not in (bundle / "app.py").read_text(encoding="utf-8")
+    generated_config = scaffold.toml.load(bundle / "config" / "defaults.toml")
+    assert generated_config["model"]["base_url"] == "https://models.example/v1"
+    assert "api_key" not in generated_config["model"]
+    for path in bundle.rglob("*"):
+        if path.is_file():
+            assert b"host-key-must-not-export" not in path.read_bytes()
+            assert b"gateway-key-must-not-export" not in path.read_bytes()
+
+
+def test_deployment_secrets_include_custom_openai_endpoint():
+    output = scaffold.generate_deployment_secrets(
+        {
+            "app": {
+                "title": "Custom Endpoint",
+                "access_mode": "public",
+                "disable_admin": True,
+            },
+            "model": {
+                "provider": "openai",
+                "name": "custom-model",
+                "base_url": "https://models.example/v1",
+            },
+        }
+    )
+
+    assert 'OPENAI_BASE_URL = "https://models.example/v1"' in output
+    assert 'OPENAI_API_KEY = "PASTE_YOUR_KEY_HERE"' in output
+
+
+def test_deployment_secrets_include_generated_hashes_without_plain_passwords():
+    shared_hash = scaffold.hash_password("shared password")
+    admin_hash = scaffold.hash_password("admin password")
+    output = scaffold.generate_deployment_secrets(
+        {
+            "app": {
+                "title": "Protected App",
+                "access_mode": "password",
+                "disable_admin": False,
+            },
+            "model": {"provider": "openai", "name": "gpt-5.4-mini"},
+        },
+        password_hashes={"shared": shared_hash, "admin": admin_hash},
+    )
+
+    assert f'SHARED_PASSWORD_HASH = "{shared_hash}"' in output
+    assert f'ADMIN_PASSWORD_HASH = "{admin_hash}"' in output
+    assert "shared password" not in output
+    assert "admin password" not in output
+    assert "PASTE_SHARED_HASH_HERE" not in output
+    assert "PASTE_ADMIN_HASH_HERE" not in output
+
+
+def test_deployment_secrets_include_selected_apim_gateway_url():
+    output = scaffold.generate_deployment_secrets(
+        {
+            "app": {
+                "title": "Gateway App",
+                "access_mode": "public",
+                "disable_admin": True,
+            },
+            "model": {
+                "provider": "azure_apim",
+                "name": "gpt-5.4-mini",
+                "base_url": "https://custom-gateway.azure-api.net/asklit",
+                "allowed_models": "gpt-5.4-mini",
+                "allow_user_selection": True,
+            },
+        }
+    )
+
+    assert (
+        'AZURE_APIM_BASE_URL = "https://custom-gateway.azure-api.net/asklit"'
+        in output
+    )


### PR DESCRIPTION
## Summary
This pull request introduces key enhancements to AskLit's project scaffolding, model configuration, and observability:

1. **GitHub OAuth Device Flow & Direct Publishing** ([asklit/github.py](file:///home/quinten/asklit/asklit/github.py)):
   - Implements GitHub OAuth device code flow so users can authorize repository creation directly in the browser without manual token copying or losing their Streamlit session.
   - Adds bundle preflighting and artifact filtering to publish clean repositories via the GitHub Contents API.

2. **OpenAI-Compatible Model Discovery & Endpoint Configuration** ([asklit/models.py](file:///home/quinten/asklit/asklit/models.py), [asklit/config.py](file:///home/quinten/asklit/asklit/config.py), [asklit/llm.py](file:///home/quinten/asklit/asklit/llm.py)):
   - Normalizes custom OpenAI-compatible base URLs and queries `/models` endpoints.
   - Distinguishes Azure AI/APIM catalogs from verified model deployments.
   - Adds support for provider overrides and non-enforced allowlist checks during experiments.

3. **AI Call Observability & Diagnostics** ([asklit/observability.py](file:///home/quinten/asklit/asklit/observability.py), [asklit/db.py](file:///home/quinten/asklit/asklit/db.py), [admin/logs.py](file:///home/quinten/asklit/admin/logs.py)):
   - Persists structured AI call events (latency, tokens, stage, errors) to SQLite with automatic secret redaction.
   - Adds an **AI Calls** tab to the admin diagnostics dashboard with expandable failure traces.

4. **Scaffolder Experiment Lab** ([asklit/experiments.py](file:///home/quinten/asklit/asklit/experiments.py), [scaffold.py](file:///home/quinten/asklit/scaffold.py)):
   - Adds a matrix evaluation lab allowing educators and developers to test combinations of prompts, knowledge bases, and models before exporting.
   - Keeps experiment traces isolated from exported bundles.

5. **Clean Production Runtime Bundling & Isolation** ([runtime/app.py](file:///home/quinten/asklit/runtime/app.py), [asklit/rag.py](file:///home/quinten/asklit/asklit/rag.py)):
   - Introduces a dedicated production runtime entrypoint template ([runtime/app.py](file:///home/quinten/asklit/runtime/app.py)) that omits the scaffolder.
   - Allows RAG keyword and vector queries to specify custom database/Chroma paths for isolated scaffolder sessions.

6. **Deployment & Documentation**:
   - Adds Fly.io container deployment configuration ([Dockerfile](file:///home/quinten/asklit/Dockerfile), [fly.toml](file:///home/quinten/asklit/fly.toml), [requirements-fly.txt](file:///home/quinten/asklit/requirements-fly.txt), [scripts/start-container.sh](file:///home/quinten/asklit/scripts/start-container.sh)).
   - Updates Azure APIM policies ([config/apim-api-policy.xml](file:///home/quinten/asklit/config/apim-api-policy.xml), [config/apim-product-policy.xml](file:///home/quinten/asklit/config/apim-product-policy.xml)) with current model list and rate limits.
   - Updates documentation in [README.md](file:///home/quinten/asklit/README.md) and [docs/](file:///home/quinten/asklit/docs/).

## Test Suite
- All 46 pytest tests pass across core quality, model discovery, GitHub OAuth flow, experiment matrix, observability, APIM gateway policies, and scaffold bundle generation.