### PR TITLE
Add resumable playground and evaluation workflows

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -1,0 +1,30 @@
+name: Deploy Fly production
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fly-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy asklit-scaffold-lab
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy and wait for health checks
+        run: flyctl deploy --remote-only --app asklit-scaffold-lab
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -4,3 +4,4 @@ port = 8501
 enableCORS = false
 enableXsrfProtection = false
 fileWatcherType = "none"
+maxUploadSize = 10

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For a more robust deployment, you can deploy it to fly.io or another inexpensive
 
 ## 🚀 Quick Start: The Scaffolder
 
-The easiest way to get started is using the **[AskLit Project Scaffolder](https://suffolklitlab.org/asklit)**. This tool allows you to build your entire app—including your knowledge base and custom branding—right in your browser, then export it directly to GitHub.
+The easiest way to get started is using the **[AskLit Project Scaffolder](https://suffolklitlab.org/asklit)**. Start in **Playground** mode to teach or explore prompt + knowledge-base design, then use its final Export step if you want to keep and deploy the project. **Builder** mode exposes the full branding, access-control, and model-configuration workflow from the beginning.
 
 ### 1. Requirements
 Before you start, make sure you have:
@@ -27,13 +27,21 @@ Before you start, make sure you have:
 3.  **AI Configuration:** Choose your model provider (e.g., OpenAI) and the model name (the default is `gpt-5.4-mini`).
 4.  **Knowledge Upload:** Drag and drop your PDFs, Word docs, or Text files. The tool will chunk and embed them locally so you can see your knowledge base built in real-time.
     *   *(Insert Screenshot: Scaffolder Step 3)*
-5.  **Experiment Lab:** Enter one representative question, select prompts, knowledge bases, and models, then compare the answers, retrieved passages, latency, and approximate tokens. The lab runs every selected combination and does not add experiment history to the exported app.
+5.  **Experiment Lab:** Create gold-labeled scenarios in an editable Streamlit table, generate grounded scenarios with AI, or upload a Promptfoo-style CSV using `input` (or `question`/`query`) and `__expected` columns. Run all scenarios against one model or use matrix mode to cross scenarios, prompts, knowledge bases, and models. Results appear in a sortable, filterable table with answers, grades, sources, latency, and approximate tokens. Experiment history is not added to the exported app.
+    *   Plain `__expected` values use exact matching. The lab also evaluates `contains:`, `icontains:`, `contains-any:`, `icontains-any:`, `contains-all:`, and `icontains-all:` assertions. Other Promptfoo assertion types remain visible and are marked ungraded.
+    *   Download the complete, unfiltered evaluation table as CSV after a run.
     *   AskLit identifies Azure AI and APIM URLs even when they use the `openai` provider alias. For small OpenAI-compatible `/models` responses, the lab shows the returned models directly. Azure `/models` responses are treated as catalog entries—not proof of deployment—so Azure experiments use the configured deployment allowlist instead.
     *   For a different Azure account, set `"model.allowed_models"` in Streamlit secrets or `MODEL_ALLOWED_MODELS` in `.env` to the deployment names that account actually exposes.
 6.  **Export & Deploy:**
     *   **Connect GitHub:** Click the button, enter AskLit's one-time code on GitHub, and approve repository access.
     *   **Secrets Generator:** Copy the pre-formatted TOML block from **Deployment Settings & Secrets**. Passwords entered in the Identity step are hashed automatically and inserted into this block.
     *   **Push:** Click "Create Repo & Push". This creates a public repository by default with your settings and documents pre-indexed. Select the private-repository checkbox first if your Streamlit plan supports private repositories.
+
+At any point, open **Save or resume** in the sidebar to download a workspace YAML file. It contains app settings, prompts, knowledge-base pairings, and evaluation scenarios, but never API keys, uploaded file contents, vector indexes, or generated evaluation answers. Importing it later starts fresh isolated storage and lists the documents or branding images that need to be uploaded again.
+
+### Classroom concurrency
+
+The hosted scaffolder isolates every browser session in its own UUID-named SQLite database, upload directory, and Chroma index. To accommodate a class of about 20 simultaneous users without overwhelming the host or model gateway, AskLit queues outbound completions at eight concurrent calls and local embedding work at two concurrent jobs by default. SQLite uses WAL mode and a busy timeout for shared diagnostic writes, and uploads are capped at 10 MB per file. Operators can tune `limits.max_concurrent_llm_calls`, `limits.llm_queue_timeout_seconds`, `limits.max_concurrent_embedding_jobs`, and `limits.embedding_queue_timeout_seconds` in configuration.
 
 ---
 

--- a/asklit/db.py
+++ b/asklit/db.py
@@ -1,7 +1,10 @@
-import sqlite3
 import os
+import sqlite3
+import threading
 
 DB_PATH_DEFAULT = os.path.join("data", "app.sqlite3")
+_INITIALIZED_PATHS = set()
+_INITIALIZATION_LOCK = threading.Lock()
 
 
 def get_db_path():
@@ -16,6 +19,8 @@ def get_connection(db_path=None):
         os.makedirs(db_dir, exist_ok=True)
     conn = sqlite3.connect(db_path, timeout=30)
     conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA busy_timeout = 30000")
+    conn.execute("PRAGMA foreign_keys = ON")
     return conn
 
 
@@ -23,8 +28,23 @@ def init_db(db_path=None):
     if db_path is None:
         db_path = get_db_path()
 
+    normalized_path = os.path.abspath(db_path)
+    if normalized_path in _INITIALIZED_PATHS and os.path.exists(normalized_path):
+        return
+
+    with _INITIALIZATION_LOCK:
+        if normalized_path in _INITIALIZED_PATHS and os.path.exists(normalized_path):
+            return
+        _initialize_db(db_path)
+        _INITIALIZED_PATHS.add(normalized_path)
+
+
+def _initialize_db(db_path):
+    """Initialize one database while callers are serialized by init_db."""
     conn = get_connection(db_path=db_path)
     cursor = conn.cursor()
+    cursor.execute("PRAGMA journal_mode = WAL")
+    cursor.execute("PRAGMA synchronous = NORMAL")
 
     # Users and Roles
     cursor.execute("""

--- a/asklit/embeddings.py
+++ b/asklit/embeddings.py
@@ -1,13 +1,55 @@
 import os
+import threading
+from contextlib import contextmanager
 
 os.environ.setdefault("PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION", "python")
 
-from chromadb import EmbeddingFunction, Documents, Embeddings
 import litellm
 import streamlit as st
-from asklit.config import get_api_key, get_setting, get_base_url
+from chromadb import Documents, EmbeddingFunction, Embeddings
+
+from asklit.config import get_api_key, get_base_url, get_setting
 
 CACHE_DIR = os.path.join("data", "model_cache")
+
+
+def _positive_int_setting(key, default):
+    try:
+        return max(int(get_setting(key, default)), 1)
+    except (TypeError, ValueError):
+        return default
+
+
+_EMBEDDING_SLOTS = None
+_EMBEDDING_SLOTS_LOCK = threading.Lock()
+
+
+def _get_embedding_slots():
+    """Create the process-wide embedding queue without config I/O at import."""
+    global _EMBEDDING_SLOTS
+    if _EMBEDDING_SLOTS is None:
+        with _EMBEDDING_SLOTS_LOCK:
+            if _EMBEDDING_SLOTS is None:
+                _EMBEDDING_SLOTS = threading.BoundedSemaphore(
+                    _positive_int_setting("limits.max_concurrent_embedding_jobs", 2)
+                )
+    return _EMBEDDING_SLOTS
+
+
+@contextmanager
+def embedding_job_slot():
+    """Bound memory-heavy embedding work across Streamlit session threads."""
+    timeout = _positive_int_setting("limits.embedding_queue_timeout_seconds", 180)
+    embedding_slots = _get_embedding_slots()
+    acquired = embedding_slots.acquire(timeout=timeout)
+    if not acquired:
+        raise RuntimeError(
+            "The knowledge-base indexer is busy with other users. Please try again."
+        )
+    try:
+        yield
+    finally:
+        embedding_slots.release()
 
 
 @st.cache_resource
@@ -63,7 +105,8 @@ def get_remote_embeddings(input_data, model=None):
             "Ocp-Apim-Subscription-Key": api_key,
         }
 
-    response = litellm.embedding(**embedding_kwargs)
+    with embedding_job_slot():
+        response = litellm.embedding(**embedding_kwargs)
     return [item["embedding"] for item in response.data]
 
 
@@ -73,7 +116,8 @@ def get_embedding(text):
 
     if use_local:
         model = get_local_model()
-        return model.encode(text).tolist()
+        with embedding_job_slot():
+            return model.encode(text).tolist()
     else:
         return get_remote_embeddings([text])[0]
 
@@ -94,7 +138,8 @@ class LiteLLMEmbeddingFunction(EmbeddingFunction):
 
         if use_local:
             model = get_local_model()
-            embeddings = model.encode(input)
+            with embedding_job_slot():
+                embeddings = model.encode(input)
             return embeddings.tolist()
         else:
             return get_remote_embeddings(input)

--- a/asklit/experiments.py
+++ b/asklit/experiments.py
@@ -1,7 +1,21 @@
+import csv
+import io
+import json
+import re
 from itertools import product
 
-
 MAX_CONTEXT_CHARS = 8000
+QUESTION_COLUMN_NAMES = ("input", "question", "query", "prompt", "text")
+EXPECTED_COLUMN_NAMES = (
+    "__expected",
+    "gold_label",
+    "goldlabel",
+    "expected",
+    "expected_answer",
+    "expectedanswer",
+    "reference_answer",
+    "referenceanswer",
+)
 
 
 def build_experiment_messages(system_prompt, user_query, context_chunks):
@@ -64,6 +78,170 @@ def build_experiment_matrix(prompt_profiles, prompt_keys, knowledgebase_keys, mo
         }
         for prompt_profile, knowledgebase_profile, model in product(
             prompts, knowledgebases, parse_model_names(models)
+        )
+    ]
+
+
+def normalize_scenario_rows(rows):
+    """Normalize editable or uploaded Promptfoo-like rows for AskLit."""
+    normalized = []
+    for index, original in enumerate(rows or []):
+        row = {str(key).strip(): value for key, value in dict(original).items()}
+        lower_keys = {key.casefold(): key for key in row}
+
+        input_key = next(
+            (lower_keys[name] for name in QUESTION_COLUMN_NAMES if name in lower_keys),
+            None,
+        )
+        if input_key is None:
+            input_key = next(
+                (key for key in row if key and not key.startswith("__")), None
+            )
+
+        expected_key = next(
+            (lower_keys[name] for name in EXPECTED_COLUMN_NAMES if name in lower_keys),
+            None,
+        )
+        description_key = lower_keys.get("__description") or lower_keys.get(
+            "description"
+        )
+        question = str(row.get(input_key, "") or "").strip()
+        if not question:
+            continue
+
+        scenario = {
+            "input": question,
+            "__expected": str(row.get(expected_key, "") or "").strip(),
+            "__description": str(
+                row.get(description_key, "") or f"Scenario {index + 1}"
+            ).strip(),
+        }
+        for key, value in row.items():
+            if key.startswith("__metadata:"):
+                scenario[key] = str(value or "").strip()
+        normalized.append(scenario)
+    return normalized
+
+
+def parse_scenario_csv(value):
+    """Read UTF-8 CSV data and return normalized Promptfoo-like scenarios."""
+    if hasattr(value, "read"):
+        value = value.read()
+    if isinstance(value, bytes):
+        value = value.decode("utf-8-sig")
+    reader = csv.DictReader(io.StringIO(str(value or "")))
+    if not reader.fieldnames:
+        raise ValueError("The CSV file needs a header row.")
+    rows = normalize_scenario_rows(reader)
+    if not rows:
+        raise ValueError(
+            "No scenarios were found. Include an input, question, query, prompt, or text column."
+        )
+    return rows
+
+
+def scenarios_to_csv(rows):
+    """Export scenarios using Promptfoo's special expected/description columns."""
+    rows = normalize_scenario_rows(rows)
+    metadata_columns = sorted(
+        {key for row in rows for key in row if key.startswith("__metadata:")}
+    )
+    output = io.StringIO()
+    fieldnames = ["input", "__expected", "__description", *metadata_columns]
+    writer = csv.DictWriter(output, fieldnames=fieldnames, extrasaction="ignore")
+    writer.writeheader()
+    writer.writerows(rows)
+    return output.getvalue()
+
+
+def parse_generated_scenarios(text):
+    """Extract a JSON scenario array from an LLM response."""
+    value = str(text or "").strip()
+    fenced = re.search(
+        r"```(?:json)?\s*(.*?)```", value, flags=re.IGNORECASE | re.DOTALL
+    )
+    if fenced:
+        value = fenced.group(1).strip()
+    if not value.startswith("["):
+        start, end = value.find("["), value.rfind("]")
+        if start >= 0 and end > start:
+            value = value[start : end + 1]
+    try:
+        payload = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            "The model did not return a valid JSON scenario list."
+        ) from exc
+    if not isinstance(payload, list):
+        raise ValueError("The model response must be a JSON list of scenarios.")
+    return normalize_scenario_rows(payload)
+
+
+def evaluate_expected(output, expected):
+    """Evaluate a transparent subset of Promptfoo's CSV assertion syntax."""
+    output = str(output or "")
+    expected = str(expected or "").strip()
+    if not expected:
+        return {"passed": None, "score": None, "reason": "No gold label"}
+
+    assertion_type = "equals"
+    assertion_value = expected
+    match = re.match(r"^([a-z-]+)(?:\([^)]*\))?\s*:\s*(.*)$", expected, re.DOTALL)
+    if match:
+        assertion_type, assertion_value = match.group(1).lower(), match.group(2)
+
+    normalized_output = " ".join(output.split())
+    normalized_value = " ".join(assertion_value.split())
+    if assertion_type == "equals":
+        passed = normalized_output == normalized_value
+    elif assertion_type == "contains":
+        passed = normalized_value in normalized_output
+    elif assertion_type == "icontains":
+        passed = normalized_value.casefold() in normalized_output.casefold()
+    elif assertion_type in {"contains-any", "icontains-any"}:
+        candidates = [
+            item.strip() for item in assertion_value.split(",") if item.strip()
+        ]
+        if assertion_type.startswith("i"):
+            passed = any(
+                item.casefold() in normalized_output.casefold() for item in candidates
+            )
+        else:
+            passed = any(item in normalized_output for item in candidates)
+    elif assertion_type in {"contains-all", "icontains-all"}:
+        candidates = [
+            item.strip() for item in assertion_value.split(",") if item.strip()
+        ]
+        if assertion_type.startswith("i"):
+            passed = all(
+                item.casefold() in normalized_output.casefold() for item in candidates
+            )
+        else:
+            passed = all(item in normalized_output for item in candidates)
+    else:
+        return {
+            "passed": None,
+            "score": None,
+            "reason": f"Unsupported assertion: {assertion_type}",
+        }
+    return {
+        "passed": passed,
+        "score": 1.0 if passed else 0.0,
+        "reason": assertion_type,
+    }
+
+
+def build_evaluation_matrix(
+    prompt_profiles, prompt_keys, knowledgebase_keys, models, scenarios
+):
+    """Return scenario × prompt × knowledge base × model combinations."""
+    combinations = build_experiment_matrix(
+        prompt_profiles, prompt_keys, knowledgebase_keys, models
+    )
+    return [
+        {**combination, "scenario": scenario}
+        for scenario, combination in product(
+            normalize_scenario_rows(scenarios), combinations
         )
     ]
 

--- a/asklit/llm.py
+++ b/asklit/llm.py
@@ -1,5 +1,8 @@
+import threading
+
 import litellm
-from asklit.config import get_api_key, get_setting, get_base_url
+
+from asklit.config import get_api_key, get_base_url, get_setting
 from asklit.observability import logger, safe_error_message
 
 
@@ -9,6 +12,25 @@ def _get_positive_int_setting(key, default):
     except (TypeError, ValueError):
         value = default
     return max(value, 1)
+
+
+# Streamlit runs each connected session in its own thread. Queue outbound calls
+# at the process boundary so a classroom-sized burst does not exhaust sockets,
+# provider quotas, or gateway connections.
+_LLM_CALL_SLOTS = None
+_LLM_CALL_SLOTS_LOCK = threading.Lock()
+
+
+def _get_llm_call_slots():
+    """Create the process-wide completion queue without reading config at import."""
+    global _LLM_CALL_SLOTS
+    if _LLM_CALL_SLOTS is None:
+        with _LLM_CALL_SLOTS_LOCK:
+            if _LLM_CALL_SLOTS is None:
+                _LLM_CALL_SLOTS = threading.BoundedSemaphore(
+                    _get_positive_int_setting("limits.max_concurrent_llm_calls", 8)
+                )
+    return _LLM_CALL_SLOTS
 
 
 def _bounded_max_tokens(max_tokens_override=None):
@@ -118,18 +140,28 @@ def call_llm(
             "model.reasoning_effort", "low"
         )
 
-    try:
-        return litellm.completion(**completion_kwargs)
-    except Exception as exc:
-        logger.error(
-            "LLM request failed provider=%s model=%s stream=%s error_type=%s error=%s",
-            provider,
-            model,
-            stream,
-            type(exc).__name__,
-            safe_error_message(exc),
+    wait_seconds = _get_positive_int_setting("limits.llm_queue_timeout_seconds", 180)
+    call_slots = _get_llm_call_slots()
+    acquired = call_slots.acquire(timeout=wait_seconds)
+    if not acquired:
+        raise RuntimeError(
+            "The AI service is busy with other playground users. Please run this test again."
         )
-        raise
+    try:
+        try:
+            return litellm.completion(**completion_kwargs)
+        except Exception as exc:
+            logger.error(
+                "LLM request failed provider=%s model=%s stream=%s error_type=%s error=%s",
+                provider,
+                model,
+                stream,
+                type(exc).__name__,
+                safe_error_message(exc),
+            )
+            raise
+    finally:
+        call_slots.release()
 
 
 def estimate_tokens(text):

--- a/config/defaults.toml
+++ b/config/defaults.toml
@@ -31,6 +31,10 @@ max_conversation_turns = 30
 max_upload_size_mb = 10
 max_prompt_length = 2000
 max_output_tokens_hard = 4000
+max_concurrent_llm_calls = 8
+llm_queue_timeout_seconds = 180
+max_concurrent_embedding_jobs = 2
+embedding_queue_timeout_seconds = 180
 
 [logging]
 enabled = true

--- a/scaffold.py
+++ b/scaffold.py
@@ -1,21 +1,30 @@
-import streamlit as st
 import os
 import shutil
 import tempfile
-import zipfile
-import toml
-import uuid
-import yaml
 import time
+import uuid
+import zipfile
+from datetime import UTC, datetime
+
+import pandas as pd
+import streamlit as st
+import toml
+import yaml
+
 from asklit.auth import hash_password
+from asklit.config import get_api_key, get_base_url, get_secret_value, get_setting
 from asklit.db import get_connection, init_db
 from asklit.experiments import (
-    build_experiment_matrix,
+    build_evaluation_matrix,
     build_experiment_messages,
+    evaluate_expected,
+    normalize_scenario_rows,
+    parse_generated_scenarios,
     parse_model_names,
+    parse_scenario_csv,
     response_text,
+    scenarios_to_csv,
 )
-from asklit.ingestion import extract_text, chunk_pages, get_content_hash
 from asklit.github import (
     GitHubError,
     get_authenticated_user,
@@ -23,6 +32,7 @@ from asklit.github import (
     publish_directory,
     request_device_code,
 )
+from asklit.ingestion import chunk_pages, extract_text, get_content_hash
 from asklit.llm import call_llm, estimate_tokens
 from asklit.models import (
     choose_model_options,
@@ -31,7 +41,6 @@ from asklit.models import (
 )
 from asklit.observability import log_ai_call_event
 from asklit.rag import add_document_to_index, query_index
-from asklit.config import get_api_key, get_base_url, get_secret_value, get_setting
 from asklit.ui import escape_html, safe_url
 
 # Constants
@@ -70,7 +79,7 @@ RECURSIVE_ARTIFACT_NAMES = {
     ".coverage",
     "htmlcov",
 }
-RECURSIVE_ARTIFACT_SUFFIXES = (".pyc", ".pyo")
+RECURSIVE_ARTIFACT_SUFFIXES = (".pyc", ".pyo", "-wal", "-shm")
 SENSITIVE_EXPORT_CONFIG_KEYS = {
     "api_key",
     "client_secret",
@@ -80,6 +89,8 @@ SENSITIVE_EXPORT_CONFIG_KEYS = {
     "shared_password_hash",
     "admin_password_hash",
 }
+WORKSPACE_SCHEMA_VERSION = 1
+MAX_WORKSPACE_YAML_BYTES = 1_000_000
 
 
 def ignore_bundle_artifacts(_directory, names):
@@ -98,8 +109,9 @@ def sanitize_export_config(value):
         sanitized = {}
         for key, child in value.items():
             normalized_key = str(key).strip().lower().replace("-", "_")
-            if normalized_key in SENSITIVE_EXPORT_CONFIG_KEYS or normalized_key.endswith(
-                "_api_key"
+            if (
+                normalized_key in SENSITIVE_EXPORT_CONFIG_KEYS
+                or normalized_key.endswith("_api_key")
             ):
                 continue
             sanitized[key] = sanitize_export_config(child)
@@ -107,6 +119,103 @@ def sanitize_export_config(value):
     if isinstance(value, list):
         return [sanitize_export_config(item) for item in value]
     return value
+
+
+def export_workspace_yaml(config_data, scenarios):
+    """Serialize resumable scaffolder fields without credentials or binary data."""
+    safe_config = sanitize_export_config(config_data)
+    profiles = normalize_prompt_profiles(safe_config.get("prompt_profiles"))
+    source_files = sorted(
+        {
+            filename
+            for profile in profiles
+            for filename in profile.get("connected_files", [])
+        },
+        key=str.casefold,
+    )
+    uploaded_assets = sorted(
+        {
+            os.path.basename(str(safe_config.get("branding", {}).get(key, "")))
+            for key in ("logo_url", "favicon_url")
+            if str(safe_config.get("branding", {}).get(key, "")).startswith("data/")
+        },
+        key=str.casefold,
+    )
+    safe_config["prompt_profiles"] = profiles
+    payload = {
+        "asklit_workspace": {
+            "schema_version": WORKSPACE_SCHEMA_VERSION,
+            "exported_at": datetime.now(UTC).isoformat(),
+            "app_config": safe_config,
+            "evaluation_scenarios": normalize_scenario_rows(scenarios),
+            "source_files_to_reupload": source_files,
+            "uploaded_assets_to_reupload": uploaded_assets,
+        }
+    }
+    return yaml.safe_dump(payload, sort_keys=False, allow_unicode=True)
+
+
+def import_workspace_yaml(value):
+    """Validate and deserialize an AskLit workspace YAML document."""
+    if hasattr(value, "read"):
+        value = value.read()
+    if isinstance(value, bytes):
+        if len(value) > MAX_WORKSPACE_YAML_BYTES:
+            raise ValueError("The workspace YAML must be 1 MB or smaller.")
+        value = value.decode("utf-8-sig")
+    elif len(str(value or "").encode("utf-8")) > MAX_WORKSPACE_YAML_BYTES:
+        raise ValueError("The workspace YAML must be 1 MB or smaller.")
+
+    try:
+        payload = yaml.safe_load(str(value or ""))
+    except yaml.YAMLError as exc:
+        raise ValueError("The workspace file is not valid YAML.") from exc
+    if not isinstance(payload, dict) or not isinstance(
+        payload.get("asklit_workspace"), dict
+    ):
+        raise ValueError("This is not an AskLit workspace YAML file.")
+
+    workspace = payload["asklit_workspace"]
+    if workspace.get("schema_version") != WORKSPACE_SCHEMA_VERSION:
+        raise ValueError("This AskLit workspace version is not supported.")
+    config_data = workspace.get("app_config")
+    if not isinstance(config_data, dict):
+        raise ValueError("The workspace is missing its app configuration.")
+    scenarios = workspace.get("evaluation_scenarios", [])
+    if not isinstance(scenarios, list):
+        raise ValueError("The workspace scenarios must be a list.")
+
+    safe_config = sanitize_export_config(config_data)
+    safe_config["prompt_profiles"] = normalize_prompt_profiles(
+        safe_config.get("prompt_profiles")
+    )
+    source_files = {
+        str(filename).strip()
+        for filename in workspace.get("source_files_to_reupload", [])
+        if str(filename).strip()
+    }
+    for profile in safe_config["prompt_profiles"]:
+        source_files.update(profile.get("connected_files", []))
+        profile["connected_files"] = []
+    uploaded_assets = {
+        str(filename).strip()
+        for filename in workspace.get("uploaded_assets_to_reupload", [])
+        if str(filename).strip()
+    }
+    branding = safe_config.get("branding", {})
+    if isinstance(branding, dict):
+        for key in ("logo_url", "favicon_url"):
+            value = str(branding.get(key, ""))
+            if value.startswith("data/"):
+                uploaded_assets.add(os.path.basename(value))
+                branding.pop(key, None)
+
+    return {
+        "app_config": safe_config,
+        "evaluation_scenarios": normalize_scenario_rows(scenarios),
+        "source_files_to_reupload": sorted(source_files, key=str.casefold),
+        "uploaded_assets_to_reupload": sorted(uploaded_assets, key=str.casefold),
+    }
 
 
 def render_password_hash_setup(label, state_key, help_text):
@@ -156,9 +265,7 @@ def discover_endpoint_models(provider, base_url):
 def get_endpoint_model_choices(provider, configured_models, base_url_override=None):
     """Choose honest runnable options without mistaking Azure's catalog for deployments."""
     base_url = (
-        base_url_override
-        if base_url_override is not None
-        else get_base_url(provider)
+        base_url_override if base_url_override is not None else get_base_url(provider)
     )
     discovery = discover_endpoint_models(provider, base_url)
     configured_models = parse_model_names(configured_models)
@@ -224,11 +331,23 @@ def create_bundle(config_data, data_dir_source):
     with open(config_path, "w") as f:
         toml.dump(toml_data, f)
 
-    # 3. Copy the built data directory (SQLite + Chroma)
+    # 3. Copy the built data directory (SQLite + Chroma). Classroom sessions use
+    # WAL for concurrent diagnostics; checkpoint first and never export sidecars.
+    source_db_path = os.path.join(data_dir_source, "app.sqlite3")
+    if os.path.exists(source_db_path):
+        conn = get_connection(db_path=source_db_path)
+        try:
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        finally:
+            conn.close()
     dst_data_dir = os.path.join(temp_dir, "data")
     if os.path.exists(dst_data_dir):
         shutil.rmtree(dst_data_dir)
-    shutil.copytree(data_dir_source, dst_data_dir)
+    shutil.copytree(
+        data_dir_source,
+        dst_data_dir,
+        ignore=ignore_bundle_artifacts,
+    )
 
     # 4. Save prompt/knowledgebase pairings as deployable YAML configs.
     prompts_dir = os.path.join(temp_dir, "prompts")
@@ -257,7 +376,8 @@ def create_bundle(config_data, data_dir_source):
     os.makedirs(st_config_dir, exist_ok=True)
     with open(os.path.join(st_config_dir, "config.toml"), "w") as f:
         f.write(
-            "[server]\nheadless = true\nenableCORS = false\nenableXsrfProtection = false\n"
+            "[server]\nheadless = true\nenableCORS = false\n"
+            "enableXsrfProtection = false\nmaxUploadSize = 10\n"
         )
 
     # 5. Add runtime-focused repository metadata and setup instructions.
@@ -357,7 +477,7 @@ def generate_deployment_secrets(config_data, password_hashes=None):
     ]
     if provider == "openai" and config_data["model"].get("base_url"):
         lines.append(
-            f'OPENAI_BASE_URL = {toml_quote(config_data["model"]["base_url"])}'
+            f"OPENAI_BASE_URL = {toml_quote(config_data['model']['base_url'])}"
         )
     if provider == "azure_apim":
         gateway_url = config_data["model"].get("base_url") or (
@@ -422,8 +542,27 @@ def get_scaffold_document_labels(db_path):
     return {row["id"]: row["filename"] for row in rows}
 
 
-def render_experiment_lab():
-    """Render a small Cartesian prompt/knowledge-base/model comparison lab."""
+def get_knowledgebase_sample(db_path, knowledgebase, max_chars=12000):
+    """Return a bounded source sample for generating grounded scenarios."""
+    conn = get_connection(db_path=db_path)
+    rows = conn.execute(
+        """
+        SELECT dc.content
+        FROM document_chunks AS dc
+        JOIN documents AS d ON d.id = dc.document_id
+        WHERE d.knowledgebase = ?
+        ORDER BY d.filename, dc.chunk_index
+        LIMIT 30
+        """,
+        (knowledgebase,),
+    ).fetchall()
+    conn.close()
+    sample = "\n\n".join(str(row["content"]) for row in rows)
+    return sample[:max_chars]
+
+
+def render_experiment_lab(playground=False):
+    """Render editable scenario evaluation in single-model or matrix mode."""
     ensure_model_defaults(st.session_state.app_config)
     profiles = normalize_prompt_profiles(
         st.session_state.app_config.get("prompt_profiles")
@@ -431,32 +570,15 @@ def render_experiment_lab():
     st.session_state.app_config["prompt_profiles"] = profiles
     model_config = st.session_state.app_config["model"]
 
-    st.header("Step 4: Experiment Lab")
+    st.header("Evaluate your playground" if playground else "Step 4: Experiment Lab")
     st.write(
-        "Ask one question across different prompts, knowledge bases, and models. "
-        "Experiments are temporary and are not included in the exported app."
+        "Build a gold-labeled scenario set, then test one model or run every "
+        "selected prompt and model as a matrix. Results stay in this browser "
+        "session and are not included in an exported app."
     )
     st.warning(
         "Each combination makes a real model call using credentials configured for this scaffolder. "
         "Your provider may charge for these calls."
-    )
-
-    labels = {profile["key"]: profile["label"] for profile in profiles}
-    prompt_keys = st.multiselect(
-        "Prompts",
-        [profile["key"] for profile in profiles],
-        default=[profiles[0]["key"]],
-        format_func=lambda key: labels[key],
-        help="The system prompt to place at the beginning of each test request.",
-    )
-    knowledgebase_keys = st.multiselect(
-        "Knowledge bases",
-        [profile["key"] for profile in profiles],
-        default=[profiles[0]["key"]],
-        format_func=lambda key: (
-            f"{labels[key]} ({next(profile['knowledgebase'] for profile in profiles if profile['key'] == key)})"
-        ),
-        help="Uses the knowledge base and connected-file filters from the selected pairing.",
     )
 
     provider_options = [
@@ -522,41 +644,227 @@ def render_experiment_lab():
         )
         render_endpoint_model_status(discovery, choice_source)
     configured_model = str(model_config.get("name", "")).strip()
-    if model_choices:
-        default_models = (
-            [configured_model]
-            if configured_model in model_choices
-            else model_choices[:1]
-        )
-        model_names = st.multiselect(
-            "Models",
-            model_choices,
-            default=default_models,
-            help="Select one or more models to compare.",
-        )
-    else:
-        model_names = st.text_area(
-            "Models (one per line or comma-separated)",
-            value=configured_model,
-            help="Use model or deployment names accepted by the selected provider.",
-        )
-    question = st.text_area(
-        "Test question",
-        placeholder="What should a user know about…?",
+    default_model = (
+        configured_model
+        if configured_model in model_choices or not model_choices
+        else model_choices[0]
     )
+
+    st.subheader("1. Gold-labeled scenarios")
+    st.caption(
+        "Edit cells directly or upload a UTF-8 CSV. AskLit accepts input/question/query "
+        "and gold_label/expected/reference_answer aliases, plus Promptfoo-style "
+        "__expected, __description, and __metadata:* columns."
+    )
+    if "evaluation_scenarios" not in st.session_state:
+        st.session_state.evaluation_scenarios = [
+            {
+                "input": "What is the most important fact a user should know?",
+                "__expected": "",
+                "__description": "Core knowledge",
+            }
+        ]
+
+    uploaded_scenarios = st.file_uploader(
+        "Upload scenario CSV", type=["csv"], key="evaluation_scenario_upload"
+    )
+    if uploaded_scenarios is not None:
+        signature = (uploaded_scenarios.name, uploaded_scenarios.size)
+        if st.session_state.get("evaluation_upload_signature") != signature:
+            try:
+                st.session_state.evaluation_scenarios = parse_scenario_csv(
+                    uploaded_scenarios.getvalue()
+                )
+                st.session_state.evaluation_upload_signature = signature
+                st.session_state.evaluation_editor_version = (
+                    st.session_state.get("evaluation_editor_version", 0) + 1
+                )
+                st.success(
+                    f"Loaded {len(st.session_state.evaluation_scenarios)} scenarios."
+                )
+            except (UnicodeDecodeError, ValueError) as exc:
+                st.error(str(exc))
+
+    scenario_frame = pd.DataFrame(st.session_state.evaluation_scenarios)
+    for required_column in ("input", "__expected", "__description"):
+        if required_column not in scenario_frame:
+            scenario_frame[required_column] = ""
+    edited_frame = st.data_editor(
+        scenario_frame,
+        num_rows="dynamic",
+        hide_index=True,
+        width="stretch",
+        column_order=["input", "__expected", "__description"],
+        column_config={
+            "input": st.column_config.TextColumn("Input", width="large", required=True),
+            "__expected": st.column_config.TextColumn(
+                "Gold label / __expected",
+                width="large",
+                help=(
+                    "Plain text means exact match. Also supports contains:, icontains:, "
+                    "contains-any:, and contains-all:."
+                ),
+            ),
+            "__description": st.column_config.TextColumn("Description", width="medium"),
+        },
+        key=(
+            f"evaluation_scenario_editor_"
+            f"{st.session_state.get('evaluation_editor_version', 0)}"
+        ),
+    )
+    st.session_state.evaluation_scenarios = normalize_scenario_rows(
+        edited_frame.fillna("").to_dict("records")
+    )
+    st.download_button(
+        "Download scenarios as CSV",
+        scenarios_to_csv(st.session_state.evaluation_scenarios),
+        "asklit-scenarios.csv",
+        "text/csv",
+    )
+
+    labels = {profile["key"]: profile["label"] for profile in profiles}
+    profile_keys = [profile["key"] for profile in profiles]
+    generation_prompt_key = st.selectbox(
+        "Prompt for scenario generation",
+        profile_keys,
+        format_func=lambda key: labels[key],
+    )
+    generation_profile = next(
+        profile for profile in profiles if profile["key"] == generation_prompt_key
+    )
+    generation_count = st.slider("Scenarios to generate", 1, 12, 5)
+    if st.button(
+        "Generate gold-labeled scenarios",
+        disabled=not provider_ready or not default_model,
+    ):
+        db_path = os.path.join(st.session_state.temp_data_dir, "app.sqlite3")
+        source_sample = get_knowledgebase_sample(
+            db_path, generation_profile["knowledgebase"]
+        )
+        generation_messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You create concise evaluation datasets. Return only a JSON array. "
+                    "Each object must contain input, __expected, and __description. "
+                    "Write realistic user questions answerable from the supplied material. "
+                    "Use an icontains: gold label containing the shortest decisive phrase "
+                    "that a correct answer must include. Do not use facts absent from the material."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    f"Create {generation_count} diverse scenarios.\n\n"
+                    f"SYSTEM PROMPT:\n{generation_profile['prompt']}\n\n"
+                    f"KNOWLEDGE BASE SAMPLE:\n{source_sample or '[No documents uploaded]'}"
+                ),
+            },
+        ]
+        try:
+            with st.spinner("Generating scenarios…"):
+                generated_response = call_llm(
+                    generation_messages,
+                    stream=False,
+                    max_tokens_override=2000,
+                    model_override=default_model,
+                    provider_override=provider,
+                    enforce_model_allowlist=False,
+                )
+                generated = parse_generated_scenarios(response_text(generated_response))
+            if not generated:
+                st.error("The model returned no usable scenarios.")
+            else:
+                st.session_state.evaluation_scenarios = generated
+                st.session_state.evaluation_editor_version = (
+                    st.session_state.get("evaluation_editor_version", 0) + 1
+                )
+                st.rerun()
+        except Exception as exc:
+            st.error(f"Scenario generation failed: {exc}")
+
+    st.subheader("2. Run settings")
+    evaluation_mode = st.radio(
+        "Evaluation shape",
+        ["Single model", "Prompt × model matrix"],
+        horizontal=True,
+        help=(
+            "Single model runs every scenario once. Matrix mode runs every scenario "
+            "through every selected prompt, knowledge base, and model."
+        ),
+    )
+    if evaluation_mode == "Single model":
+        prompt_keys = [
+            st.selectbox(
+                "Prompt",
+                profile_keys,
+                format_func=lambda key: labels[key],
+                key="single_evaluation_prompt",
+            )
+        ]
+        knowledgebase_keys = [
+            st.selectbox(
+                "Knowledge base",
+                profile_keys,
+                format_func=lambda key: (
+                    f"{labels[key]} ({next(profile['knowledgebase'] for profile in profiles if profile['key'] == key)})"
+                ),
+                key="single_evaluation_knowledgebase",
+            )
+        ]
+        if model_choices:
+            model_names = [
+                st.selectbox(
+                    "Model",
+                    model_choices,
+                    index=model_choices.index(default_model),
+                    key="single_evaluation_model",
+                )
+            ]
+        else:
+            model_names = st.text_input(
+                "Model", value=default_model, key="single_evaluation_model_text"
+            )
+    else:
+        prompt_keys = st.multiselect(
+            "Prompts",
+            profile_keys,
+            default=[profile_keys[0]],
+            format_func=lambda key: labels[key],
+        )
+        knowledgebase_keys = st.multiselect(
+            "Knowledge bases",
+            profile_keys,
+            default=[profile_keys[0]],
+            format_func=lambda key: (
+                f"{labels[key]} ({next(profile['knowledgebase'] for profile in profiles if profile['key'] == key)})"
+            ),
+        )
+        if model_choices:
+            model_names = st.multiselect(
+                "Models", model_choices, default=[default_model]
+            )
+        else:
+            model_names = st.text_area(
+                "Models (one per line or comma-separated)", value=default_model
+            )
     top_k = st.slider("Retrieved passages per run", 1, 10, 5)
 
-    matrix = build_experiment_matrix(
-        profiles, prompt_keys, knowledgebase_keys, model_names
+    matrix = build_evaluation_matrix(
+        profiles,
+        prompt_keys,
+        knowledgebase_keys,
+        model_names,
+        st.session_state.evaluation_scenarios,
     )
     run_count = len(matrix)
     if run_count:
         st.caption(f"{run_count} model call{'s' if run_count != 1 else ''} will run.")
-    if run_count > 12:
-        st.error("Choose fewer options so the experiment has no more than 12 runs.")
+    if run_count > 60:
+        st.error("Reduce the matrix to 60 model calls or fewer.")
 
-    can_run = bool(question.strip() and matrix and run_count <= 12 and provider_ready)
-    if st.button("Run experiment", type="primary", disabled=not can_run):
+    can_run = bool(matrix and run_count <= 60 and provider_ready)
+    if st.button("Run evaluation", type="primary", disabled=not can_run):
         experiment_run_id = str(uuid.uuid4())
         db_path = os.path.join(st.session_state.temp_data_dir, "app.sqlite3")
         chroma_path = os.path.join(st.session_state.temp_data_dir, "chroma")
@@ -568,9 +876,14 @@ def render_experiment_lab():
             prompt_profile = combination["prompt"]
             knowledgebase_profile = combination["knowledgebase"]
             model = combination["model"]
+            scenario = combination["scenario"]
+            question = scenario["input"]
             progress.progress(
                 index / run_count,
-                text=f"Running {prompt_profile['label']} × {knowledgebase_profile['label']} × {model}",
+                text=(
+                    f"Scenario {index + 1}/{run_count}: "
+                    f"{prompt_profile['label']} × {model}"
+                ),
             )
             started = time.perf_counter()
             context_chunks = []
@@ -633,6 +946,15 @@ def render_experiment_lab():
                 tokens_in=input_tokens,
                 tokens_out=estimate_tokens(answer),
             )
+            grade = (
+                {
+                    "passed": None,
+                    "score": None,
+                    "reason": "Model call failed",
+                }
+                if error
+                else evaluate_expected(answer, scenario.get("__expected", ""))
+            )
 
             results.append(
                 {
@@ -642,11 +964,17 @@ def render_experiment_lab():
                     "knowledgebase": knowledgebase_profile["knowledgebase"],
                     "model": model,
                     "provider": provider,
+                    "scenario": scenario.get("__description") or question,
+                    "input": question,
+                    "expected": scenario.get("__expected", ""),
                     "answer": answer,
+                    "passed": grade["passed"],
+                    "score": grade["score"],
+                    "grade_reason": grade["reason"],
                     "error": safe_error,
                     "failure_stage": failure_stage,
                     "elapsed": elapsed,
-                    "tokens": estimate_tokens(question) + estimate_tokens(answer),
+                    "tokens": input_tokens + estimate_tokens(answer),
                     "sources": [
                         {
                             "filename": document_labels.get(
@@ -662,39 +990,288 @@ def render_experiment_lab():
             )
         progress.progress(1.0, text="Experiment complete")
         st.session_state.experiment_results = results
-        st.session_state.experiment_question = question
 
     results = st.session_state.get("experiment_results", [])
     if results:
-        st.subheader("Results")
-        st.caption(f"Question: {st.session_state.get('experiment_question', question)}")
-        columns = st.columns(min(3, len(results)))
-        for index, result in enumerate(results):
-            with columns[index % len(columns)]:
-                st.markdown(
-                    f"#### {result['prompt_label']} × {result['knowledgebase_label']}"
+        st.subheader("3. Results")
+        passed = sum(result["passed"] is True for result in results)
+        graded = sum(result["passed"] is not None for result in results)
+        metric_columns = st.columns(3)
+        metric_columns[0].metric("Runs", len(results))
+        metric_columns[1].metric("Graded", graded)
+        metric_columns[2].metric(
+            "Pass rate", f"{passed / graded:.0%}" if graded else "—"
+        )
+
+        filter_columns = st.columns(3)
+        prompt_filter = filter_columns[0].multiselect(
+            "Filter prompts",
+            sorted({result["prompt_label"] for result in results}),
+        )
+        model_filter = filter_columns[1].multiselect(
+            "Filter models", sorted({result["model"] for result in results})
+        )
+        outcome_filter = filter_columns[2].multiselect(
+            "Filter outcomes", ["Pass", "Fail", "Not graded", "Error"]
+        )
+
+        all_table_rows = []
+        for result in results:
+            outcome = (
+                "Error"
+                if result["error"]
+                else "Pass"
+                if result["passed"] is True
+                else "Fail"
+                if result["passed"] is False
+                else "Not graded"
+            )
+            source_labels = ", ".join(
+                f"{source['filename']} p.{source['page']}"
+                for source in result["sources"]
+            )
+            retrieved_context = "\n\n".join(
+                f"[{source['filename']} p.{source['page']}]\n{source['content']}"
+                for source in result["sources"]
+            )
+            all_table_rows.append(
+                {
+                    "Run ID": result["run_id"],
+                    "Outcome": outcome,
+                    "Scenario": result["scenario"],
+                    "Input": result["input"],
+                    "Prompt": result["prompt_label"],
+                    "Knowledge base": result["knowledgebase_label"],
+                    "Model": result["model"],
+                    "Provider": result["provider"],
+                    "Gold label": result["expected"],
+                    "Answer": result["answer"],
+                    "Grade": result["grade_reason"],
+                    "Score": result["score"],
+                    "Latency (s)": round(result["elapsed"], 2),
+                    "Approx. tokens": result["tokens"],
+                    "Sources": source_labels,
+                    "Retrieved context": retrieved_context,
+                    "Knowledge-base key": result["knowledgebase"],
+                    "Failure stage": result["failure_stage"] or "",
+                    "Error": result["error"] or "",
+                }
+            )
+        st.download_button(
+            "Download all evaluation results as CSV",
+            pd.DataFrame(all_table_rows).to_csv(index=False),
+            file_name="asklit-evaluation-results.csv",
+            mime="text/csv",
+        )
+        table_rows = [
+            row
+            for row in all_table_rows
+            if (not prompt_filter or row["Prompt"] in prompt_filter)
+            and (not model_filter or row["Model"] in model_filter)
+            and (not outcome_filter or row["Outcome"] in outcome_filter)
+        ]
+        st.dataframe(
+            pd.DataFrame(table_rows),
+            hide_index=True,
+            width="stretch",
+            column_order=[
+                "Outcome",
+                "Scenario",
+                "Input",
+                "Prompt",
+                "Knowledge base",
+                "Model",
+                "Gold label",
+                "Answer",
+                "Grade",
+                "Latency (s)",
+                "Approx. tokens",
+                "Sources",
+                "Error",
+            ],
+            column_config={
+                "Answer": st.column_config.TextColumn(width="large"),
+                "Input": st.column_config.TextColumn(width="large"),
+                "Gold label": st.column_config.TextColumn(width="medium"),
+                "Latency (s)": st.column_config.NumberColumn(format="%.2f"),
+            },
+        )
+        if playground:
+            st.success(
+                "Ready to keep this project? Choose **4. Export** in the sidebar."
+            )
+
+
+def render_playground_prompt_editor():
+    """Render the smallest useful prompt + knowledge-base pairing lesson."""
+    st.header("Write a prompt")
+    st.write(
+        "A prompt tells the assistant how to behave. The knowledge-base name tells "
+        "AskLit which uploaded sources this prompt may search. Nothing is published "
+        "unless you later choose Export."
+    )
+    profiles = normalize_prompt_profiles(
+        st.session_state.app_config.get("prompt_profiles")
+    )
+    st.session_state.app_config["prompt_profiles"] = profiles
+
+    selected_index = st.selectbox(
+        "Prompt to edit",
+        range(len(profiles)),
+        format_func=lambda index: profiles[index]["label"],
+    )
+    profile = profiles[selected_index]
+    profile["label"] = st.text_input("Prompt name", profile["label"])
+    profile["knowledgebase"] = st.text_input(
+        "Knowledge-base name",
+        profile["knowledgebase"],
+        help="Prompts with the same knowledge-base name search the same uploaded sources.",
+    )
+    profile["prompt"] = st.text_area(
+        "System prompt",
+        profile["prompt"],
+        height=280,
+        help="Describe the assistant's role, audience, boundaries, and desired answer style.",
+    )
+    profile["key"] = slugify_key(profile["label"], profile["key"])
+
+    action_columns = st.columns(2)
+    if action_columns[0].button("Add another prompt"):
+        next_number = len(profiles) + 1
+        profiles.append(
+            {
+                "key": f"prompt-{next_number}",
+                "label": f"Prompt {next_number}",
+                "knowledgebase": profile["knowledgebase"],
+                "prompt": profile["prompt"],
+                "conversation_starters": [],
+                "connected_files": [],
+            }
+        )
+        st.rerun()
+    if len(profiles) > 1 and action_columns[1].button("Remove this prompt"):
+        profiles.pop(selected_index)
+        st.rerun()
+
+    st.info("Next, upload a document to give this prompt a knowledge base.")
+
+
+def default_scaffold_config(playground=False):
+    """Return a complete configuration for a new browser workspace."""
+    return {
+        "app": {
+            "title": "My Knowledge Base",
+            "welcome_message": "How can I help you today?",
+            "access_mode": "public" if playground else "password",
+            "disable_admin": playground,
+        },
+        "model": {},
+        "retrieval": {},
+        "limits": {},
+        "logging": {"enabled": True},
+        "branding": {
+            "favicon_url": "https://github.com/SuffolkLITLab/logos/raw/main/current-logo/png/lit-favicon.png",
+            "logo_url": "https://github.com/SuffolkLITLab/logos/raw/main/current-logo/png/lit-lab-logo-large.png",
+            "homepage_url": "https://suffolklitlab.org",
+            "supplemental_footer_text": "",
+            "hide_asklit_badge": False,
+        },
+        "prompt_profiles": [
+            {
+                "key": "default",
+                "label": "Default",
+                "knowledgebase": "default",
+                "prompt": "You are a helpful assistant.",
+                "conversation_starters": [],
+                "connected_files": [],
+            }
+        ],
+    }
+
+
+def merge_workspace_config(defaults, imported):
+    """Recursively merge a validated workspace onto current schema defaults."""
+    merged = dict(defaults)
+    for key, value in imported.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = merge_workspace_config(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def initialize_scaffold_storage():
+    """Create isolated database/vector storage for the current browser session."""
+    st.session_state.scaffold_id = str(uuid.uuid4())
+    st.session_state.temp_data_dir = os.path.join(
+        tempfile.gettempdir(), f"asklit_data_{st.session_state.scaffold_id}"
+    )
+    os.makedirs(st.session_state.temp_data_dir, exist_ok=True)
+    init_db(os.path.join(st.session_state.temp_data_dir, "app.sqlite3"))
+
+
+def render_workspace_controls(playground):
+    """Render YAML save/resume controls shared by both scaffolder modes."""
+    with st.sidebar.expander("Save or resume", expanded=False):
+        st.caption(
+            "Workspace YAML saves settings, prompts, and scenarios—not API keys, "
+            "uploaded documents/images, or generated answers."
+        )
+        workspace_yaml = export_workspace_yaml(
+            st.session_state.app_config,
+            st.session_state.get("evaluation_scenarios", []),
+        )
+        st.download_button(
+            "Download workspace YAML",
+            workspace_yaml,
+            file_name="asklit-workspace.yml",
+            mime="application/x-yaml",
+        )
+        uploaded_workspace = st.file_uploader(
+            "Import workspace YAML",
+            type=["yml", "yaml"],
+            key="workspace_yaml_upload",
+        )
+        if st.button(
+            "Import and replace current workspace",
+            disabled=uploaded_workspace is None,
+        ):
+            try:
+                imported = import_workspace_yaml(uploaded_workspace.getvalue())
+            except (UnicodeDecodeError, ValueError) as exc:
+                st.error(str(exc))
+            else:
+                imported_config = merge_workspace_config(
+                    default_scaffold_config(playground), imported["app_config"]
                 )
-                st.caption(
-                    f"{result['model']} via {result['provider']} · "
-                    f"{result['elapsed']:.1f}s · ~{result['tokens']} tokens · "
-                    f"run {result['run_id'][:8]}"
+                scenarios = imported["evaluation_scenarios"]
+                source_files = imported["source_files_to_reupload"]
+                uploaded_assets = imported["uploaded_assets_to_reupload"]
+                st.query_params["workspace_mode"] = (
+                    "playground" if playground else "builder"
                 )
-                if result["error"]:
-                    st.error(
-                        f"{result['failure_stage'].title()} failed: {result['error']}"
-                    )
-                else:
-                    st.markdown(result["answer"])
-                with st.expander(f"Retrieved sources ({len(result['sources'])})"):
-                    if not result["sources"]:
-                        st.write("No matching passages were retrieved.")
-                    for source_index, source in enumerate(result["sources"]):
-                        page = source["page"] if source["page"] is not None else "N/A"
-                        st.markdown(
-                            f"**Source {source_index + 1}: {source['filename']}, page {page}**"
-                        )
-                        st.write(source["content"])
-                        st.divider()
+                st.session_state.clear()
+                initialize_scaffold_storage()
+                st.session_state.app_config = imported_config
+                st.session_state.evaluation_scenarios = scenarios
+                st.session_state.workspace_source_files = source_files
+                st.session_state.workspace_uploaded_assets = uploaded_assets
+                st.session_state.workspace_imported = True
+                st.rerun()
+
+    if st.session_state.get("workspace_imported"):
+        st.sidebar.success("Workspace imported.")
+        source_files = st.session_state.get("workspace_source_files", [])
+        if source_files:
+            st.sidebar.warning(
+                "Re-upload these knowledge-base files: " + ", ".join(source_files)
+            )
+        uploaded_assets = st.session_state.get("workspace_uploaded_assets", [])
+        if uploaded_assets:
+            st.sidebar.warning(
+                "Re-upload these branding images in Builder mode: "
+                + ", ".join(uploaded_assets)
+            )
 
 
 def main():
@@ -716,68 +1293,75 @@ def main():
         )
         st.sidebar.divider()
 
-    st.title("🏗️ AskLit Project Scaffolder")
-    st.markdown("""
-    Create your own private AI Knowledge Base app in minutes. 
-    This tool will help you configure your app, upload your documents, 
-    and bundle everything into a GitHub-ready repository.
-    """)
+    resumed_mode = st.query_params.get("workspace_mode")
+    workflow_mode = st.sidebar.radio(
+        "Mode",
+        ["Playground", "Builder — export an app"],
+        index=1 if resumed_mode == "builder" else 0,
+        help=(
+            "Playground starts with prompt, knowledge-base, and evaluation exercises; "
+            "you can still export the finished project."
+        ),
+    )
+    if resumed_mode:
+        del st.query_params["workspace_mode"]
+    playground = workflow_mode == "Playground"
+    if playground:
+        st.title("🧪 AskLit Playground")
+        st.markdown(
+            "Learn how a prompt and knowledge base work together, then evaluate "
+            "gold-labeled scenarios. Export the project if you decide to keep it."
+        )
+    else:
+        st.title("🏗️ AskLit Project Scaffolder")
+        st.markdown(
+            "Configure, test, and bundle a private knowledge-base app into a "
+            "GitHub-ready repository."
+        )
 
     if "scaffold_id" not in st.session_state:
-        st.session_state.scaffold_id = str(uuid.uuid4())
-        # Create a unique data directory for this session's build
-        st.session_state.temp_data_dir = os.path.join(
-            tempfile.gettempdir(), f"asklit_data_{st.session_state.scaffold_id}"
-        )
-        os.makedirs(st.session_state.temp_data_dir, exist_ok=True)
-        # Initialize a fresh DB in the temp dir
-        db_path = os.path.join(st.session_state.temp_data_dir, "app.sqlite3")
-        init_db(db_path)
+        initialize_scaffold_storage()
 
     if "app_config" not in st.session_state:
-        st.session_state.app_config = {
-            "app": {
-                "title": "My Knowledge Base",
-                "welcome_message": "How can I help you today?",
-                "access_mode": "password",
-            },
-            "model": {},
-            "retrieval": {},
-            "limits": {},
-            "logging": {"enabled": True},
-            "branding": {
-                "favicon_url": "https://github.com/SuffolkLITLab/logos/raw/main/current-logo/png/lit-favicon.png",
-                "logo_url": "https://github.com/SuffolkLITLab/logos/raw/main/current-logo/png/lit-lab-logo-large.png",
-                "homepage_url": "https://suffolklitlab.org",
-                "supplemental_footer_text": "",
-                "hide_asklit_badge": False,
-            },
-            "prompt_profiles": [
-                {
-                    "key": "default",
-                    "label": "Default",
-                    "knowledgebase": "default",
-                    "prompt": "You are a helpful assistant.",
-                    "conversation_starters": [],
-                    "connected_files": [],
-                }
-            ],
-        }
+        st.session_state.app_config = default_scaffold_config(playground)
     ensure_model_defaults(st.session_state.app_config)
+    render_workspace_controls(playground)
 
     # Sidebar Navigation
-    step = st.sidebar.radio(
-        "Steps",
-        [
-            "1. Identity",
-            "2. AI Model",
-            "3. Knowledge",
-            "4. Experiment Lab",
-            "5. Export",
-        ],
-    )
+    if playground:
+        step = st.sidebar.radio(
+            "Playground steps",
+            ["1. Prompt", "2. Knowledge", "3. Evaluate", "4. Export"],
+        )
+        step_key = {
+            "1. Prompt": "identity",
+            "2. Knowledge": "knowledge",
+            "3. Evaluate": "experiment",
+            "4. Export": "export",
+        }[step]
+    else:
+        step = st.sidebar.radio(
+            "Builder steps",
+            [
+                "1. Identity",
+                "2. AI Model",
+                "3. Knowledge",
+                "4. Experiment Lab",
+                "5. Export",
+            ],
+        )
+        step_key = {
+            "1. Identity": "identity",
+            "2. AI Model": "model",
+            "3. Knowledge": "knowledge",
+            "4. Experiment Lab": "experiment",
+            "5. Export": "export",
+        }[step]
 
-    if step == "1. Identity":
+    if step_key == "identity" and playground:
+        render_playground_prompt_editor()
+
+    elif step_key == "identity":
         st.header("Step 1: App Identity & Branding")
 
         st.subheader("Basic Information")
@@ -964,7 +1548,7 @@ def main():
             st.session_state.app_config["branding"]["hide_asklit_badge"],
         )
 
-    elif step == "2. AI Model":
+    elif step_key == "model":
         st.header("Step 2: AI Configuration")
         st.info(
             "You won't provide API keys here. The scaffolder's own credentials are "
@@ -1129,8 +1713,8 @@ def main():
         }
         st.success("Using local embeddings (no API key needed during scaffolding!)")
 
-    elif step == "3. Knowledge":
-        st.header("Step 3: Upload Knowledge")
+    elif step_key == "knowledge":
+        st.header("Add a knowledge base" if playground else "Step 3: Upload Knowledge")
         st.write("Upload the PDFs or documents you want your AI to know about.")
         st.session_state.app_config["prompt_profiles"] = normalize_prompt_profiles(
             st.session_state.app_config.get("prompt_profiles")
@@ -1225,12 +1809,20 @@ def main():
 
                     st.success(f"Indexed {len(uploaded_files)} documents!")
 
-    elif step == "4. Experiment Lab":
-        render_experiment_lab()
+    elif step_key == "experiment":
+        render_experiment_lab(playground=playground)
 
-    elif step == "5. Export":
+    elif step_key == "export":
         ensure_model_defaults(st.session_state.app_config)
-        st.header("Step 5: Export your Project")
+        st.header(
+            "Export your project" if playground else "Step 5: Export your Project"
+        )
+        if playground:
+            st.info(
+                "Playground projects start with public access and the admin backend "
+                "disabled. Switch to Builder first if you want passwords, branding, "
+                "or detailed deployment settings."
+            )
 
         # 1. Configuration Generator
         with st.expander("📋 Deployment Settings & Secrets", expanded=True):

--- a/scripts/start-container.sh
+++ b/scripts/start-container.sh
@@ -9,4 +9,5 @@ fi
 exec streamlit run app.py \
   --server.port=8501 \
   --server.address=0.0.0.0 \
-  --server.headless=true
+  --server.headless=true \
+  --server.maxUploadSize=10

--- a/test_experiments.py
+++ b/test_experiments.py
@@ -1,12 +1,16 @@
 from types import SimpleNamespace
 
 from asklit.experiments import (
+    build_evaluation_matrix,
     build_experiment_matrix,
     build_experiment_messages,
+    evaluate_expected,
+    parse_generated_scenarios,
     parse_model_names,
+    parse_scenario_csv,
     response_text,
+    scenarios_to_csv,
 )
-
 
 PROFILES = [
     {
@@ -65,3 +69,74 @@ def test_response_text_supports_object_and_dict_responses():
 
     assert response_text(object_response) == "Object answer"
     assert response_text(dict_response) == "Dict answer"
+
+
+def test_promptfoo_style_csv_and_aliases_are_normalized():
+    rows = parse_scenario_csv(
+        "question,__expected,__description,__metadata:topic\n"
+        '"Where?","icontains:Boston","Location","housing"\n'
+    )
+
+    assert rows == [
+        {
+            "input": "Where?",
+            "__expected": "icontains:Boston",
+            "__description": "Location",
+            "__metadata:topic": "housing",
+        }
+    ]
+    assert (
+        parse_scenario_csv("query,gold_label\nWhat?,Answer\n")[0]["__expected"]
+        == "Answer"
+    )
+    assert (
+        parse_scenario_csv("question,expectedAnswer\nWhy?,Because\n")[0]["__expected"]
+        == "Because"
+    )
+
+
+def test_scenario_csv_round_trip_preserves_promptfoo_columns():
+    original = [
+        {
+            "input": "What?",
+            "__expected": "contains:answer",
+            "__description": "Basic",
+            "__metadata:topic": "demo",
+        }
+    ]
+
+    assert parse_scenario_csv(scenarios_to_csv(original)) == original
+
+
+def test_supported_gold_assertions_are_transparent_and_deterministic():
+    assert evaluate_expected("The Answer is Boston.", "icontains:boston")["passed"]
+    assert evaluate_expected("red and blue", "contains-all:red,blue")["passed"]
+    assert not evaluate_expected("red", "contains-all:red,blue")["passed"]
+    unsupported = evaluate_expected("anything", "llm-rubric:Be correct")
+    assert unsupported["passed"] is None
+    assert unsupported["reason"] == "Unsupported assertion: llm-rubric"
+
+
+def test_generated_scenarios_accept_fenced_json():
+    rows = parse_generated_scenarios(
+        '```json\n[{"input":"Question?","__expected":"contains:Answer"}]\n```'
+    )
+
+    assert rows[0]["input"] == "Question?"
+    assert rows[0]["__expected"] == "contains:Answer"
+
+
+def test_evaluation_matrix_crosses_scenarios_prompts_and_models():
+    matrix = build_evaluation_matrix(
+        PROFILES,
+        ["housing", "benefits"],
+        ["housing"],
+        ["model-a", "model-b"],
+        [
+            {"input": "First", "__expected": "one"},
+            {"input": "Second", "__expected": "two"},
+        ],
+    )
+
+    assert len(matrix) == 8
+    assert {item["scenario"]["input"] for item in matrix} == {"First", "Second"}

--- a/test_gateway_security.py
+++ b/test_gateway_security.py
@@ -1,9 +1,53 @@
 import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
 sys.modules.setdefault("litellm", SimpleNamespace())
 
 from asklit import llm
+
+
+def test_classroom_burst_is_bounded_by_shared_completion_slots(monkeypatch):
+    settings = {
+        "model.name": "test-model",
+        "model.provider": "openai",
+        "model.temperature": "1.0",
+        "model.disable_temperature": "false",
+        "model.max_tokens": "100",
+        "limits.max_output_tokens_hard": "100",
+        "limits.llm_queue_timeout_seconds": "5",
+    }
+    state = {"active": 0, "maximum": 0}
+    state_lock = threading.Lock()
+
+    def completion(**_kwargs):
+        with state_lock:
+            state["active"] += 1
+            state["maximum"] = max(state["maximum"], state["active"])
+        time.sleep(0.02)
+        with state_lock:
+            state["active"] -= 1
+        return "response"
+
+    monkeypatch.setattr(
+        llm, "get_setting", lambda key, default=None: settings.get(key, default)
+    )
+    monkeypatch.setattr(llm, "get_api_key", lambda _provider: "test-key")
+    monkeypatch.setattr(llm, "get_base_url", lambda _provider: None)
+    monkeypatch.setattr(llm.litellm, "completion", completion, raising=False)
+
+    with ThreadPoolExecutor(max_workers=20) as executor:
+        results = list(
+            executor.map(
+                lambda _index: llm.call_llm([{"role": "user", "content": "Hello"}]),
+                range(20),
+            )
+        )
+
+    assert results == ["response"] * 20
+    assert 1 < state["maximum"] <= 8
 
 
 def test_azure_apim_uses_gateway_header_and_openai_compatibility(monkeypatch):

--- a/test_observability.py
+++ b/test_observability.py
@@ -1,3 +1,5 @@
+from concurrent.futures import ThreadPoolExecutor
+
 from asklit.db import get_connection
 from asklit.observability import log_ai_call_event, safe_error_message
 
@@ -42,3 +44,28 @@ def test_failed_ai_call_is_persisted(monkeypatch, tmp_path):
     assert row["stage"] == "completion"
     assert row["error_type"] == "RuntimeError"
     assert row["error_message"] == "Gateway returned 403"
+
+
+def test_concurrent_diagnostic_writes_do_not_lock_database(monkeypatch, tmp_path):
+    db_path = tmp_path / "classroom.sqlite3"
+    monkeypatch.setenv("ASKLIT_DB_PATH", str(db_path))
+
+    def write_event(index):
+        log_ai_call_event(
+            run_id=f"run-{index}",
+            source="experiment_lab",
+            provider="openai",
+            model="test-model",
+            status="succeeded",
+        )
+
+    with ThreadPoolExecutor(max_workers=20) as executor:
+        list(executor.map(write_event, range(20)))
+
+    conn = get_connection()
+    count = conn.execute("SELECT COUNT(*) FROM ai_call_events").fetchone()[0]
+    journal_mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+    conn.close()
+
+    assert count == 20
+    assert journal_mode == "wal"

--- a/test_scaffold_bundle.py
+++ b/test_scaffold_bundle.py
@@ -10,6 +10,55 @@ def test_production_runtime_entrypoint_has_no_scaffolder_page_reference():
     assert "scaffold.py" not in runtime_app.read_text(encoding="utf-8")
 
 
+def test_workspace_yaml_round_trip_excludes_secrets_and_binary_state():
+    workspace_yaml = scaffold.export_workspace_yaml(
+        {
+            "app": {"title": "Class project"},
+            "model": {"name": "test-model", "api_key": "must-not-serialize"},
+            "branding": {
+                "logo_url": "data/assets/uploaded-logo.png",
+                "homepage_url": "https://example.org",
+            },
+            "prompt_profiles": [
+                {
+                    "key": "housing",
+                    "label": "Housing",
+                    "knowledgebase": "housing",
+                    "prompt": "Use the housing guide.",
+                    "connected_files": ["housing-guide.pdf"],
+                }
+            ],
+        },
+        [
+            {
+                "input": "What should I do?",
+                "__expected": "icontains:notice",
+                "__description": "Notice",
+            }
+        ],
+    )
+
+    assert "must-not-serialize" not in workspace_yaml
+    imported = scaffold.import_workspace_yaml(workspace_yaml)
+    assert imported["app_config"]["app"]["title"] == "Class project"
+    assert imported["app_config"]["prompt_profiles"][0]["connected_files"] == []
+    assert imported["source_files_to_reupload"] == ["housing-guide.pdf"]
+    assert imported["uploaded_assets_to_reupload"] == ["uploaded-logo.png"]
+    assert "logo_url" not in imported["app_config"]["branding"]
+    assert imported["evaluation_scenarios"][0]["input"] == "What should I do?"
+
+
+def test_workspace_yaml_rejects_unknown_schema():
+    try:
+        scaffold.import_workspace_yaml(
+            "asklit_workspace:\n  schema_version: 999\n  app_config: {}\n"
+        )
+    except ValueError as exc:
+        assert "version" in str(exc).lower()
+    else:
+        raise AssertionError("Expected an unknown workspace schema to be rejected")
+
+
 def test_create_bundle_recursively_excludes_local_artifacts(monkeypatch, tmp_path):
     source_root = tmp_path / "source"
     source_root.mkdir()
@@ -57,7 +106,7 @@ def test_create_bundle_recursively_excludes_local_artifacts(monkeypatch, tmp_pat
 
     session_data = tmp_path / "session-data"
     session_data.mkdir()
-    (session_data / "app.sqlite3").write_bytes(b"database")
+    scaffold.init_db(str(session_data / "app.sqlite3"))
     monkeypatch.setattr(scaffold, "__file__", str(source_root / "scaffold.py"))
 
     bundle = Path(
@@ -81,6 +130,8 @@ def test_create_bundle_recursively_excludes_local_artifacts(monkeypatch, tmp_pat
     assert (bundle / "admin" / "settings.py").exists()
     assert (bundle / "asklit" / "config.py").exists()
     assert (bundle / "data" / "app.sqlite3").exists()
+    assert not list((bundle / "data").glob("*-wal"))
+    assert not list((bundle / "data").glob("*-shm"))
     assert (bundle / "prompts" / "default.yml").exists()
     assert not list(bundle.rglob("__pycache__"))
     assert not list(bundle.rglob("*.pyc"))
@@ -114,6 +165,9 @@ def test_create_bundle_recursively_excludes_local_artifacts(monkeypatch, tmp_pat
         scaffold.RUNTIME_ASKLIT_MODULES
     )
     assert "scaffold.py" not in (bundle / "app.py").read_text(encoding="utf-8")
+    assert "maxUploadSize = 10" in (bundle / ".streamlit" / "config.toml").read_text(
+        encoding="utf-8"
+    )
     generated_config = scaffold.toml.load(bundle / "config" / "defaults.toml")
     assert generated_config["model"]["base_url"] == "https://models.example/v1"
     assert "api_key" not in generated_config["model"]
@@ -185,6 +239,5 @@ def test_deployment_secrets_include_selected_apim_gateway_url():
     )
 
     assert (
-        'AZURE_APIM_BASE_URL = "https://custom-gateway.azure-api.net/asklit"'
-        in output
+        'AZURE_APIM_BASE_URL = "https://custom-gateway.azure-api.net/asklit"' in output
     )


### PR DESCRIPTION
## Summary

This turns the scaffolder into a classroom-friendly playground without making the playground a dead end. Students can author a prompt, upload knowledge, build or import gold-labeled scenarios, compare one or many prompt/model combinations, save their unfinished work, and export a deployable AskLit project when ready.

## User-facing changes

- Add a clear `Playground` mode with Prompt → Knowledge → Evaluate → Export steps.
- Keep the full Builder workflow for branding, access controls, and detailed model configuration.
- Add editable and uploadable Promptfoo-style scenario tables.
- Generate grounded gold-labeled scenarios with the selected AI model.
- Run either a single-model evaluation or a scenario × prompt × knowledge-base × model matrix.
- Replace result cards with a sortable/filterable Streamlit dataframe.
- Download complete evaluation results as CSV, including scores, errors, timings, citations, and retrieved context.
- Download/import a versioned workspace YAML containing configuration, prompts, pairings, and scenarios.
- Never serialize API keys, generated answers, uploaded contents, or vector indexes; imported workspaces list documents and branding files that must be re-uploaded.

## Classroom concurrency

- Preserve UUID-isolated SQLite, upload, and Chroma storage per browser session.
- Bound process-wide completion traffic to 8 concurrent calls and embedding work to 2 concurrent jobs by default, with configurable queue timeouts.
- Enable SQLite WAL, busy timeouts, and serialized schema initialization for shared diagnostics.
- Cap uploads at 10 MB in both Streamlit Cloud configuration and the Fly container command.
- Checkpoint WAL data and exclude SQLite sidecars from generated project bundles.

## Deployment

### Streamlit Community Cloud

The connected Streamlit scaffold app continues to run `app.py` and receives the tracked `.streamlit/config.toml`. Merging to `main` should trigger Streamlit Cloud's normal branch-based redeploy. Both `https://asklit-scaffold.streamlit.app/` and `https://asklit.streamlit.app/` currently respond with the expected Streamlit authentication redirect.

### Fly.io

- Add a `main`-branch GitHub Actions workflow that runs `flyctl deploy --remote-only --app asklit-scaffold-lab`.
- Install a one-year, app-scoped Fly deploy token as the repository `FLY_API_TOKEN` Actions secret; no personal Fly token is used.
- Keep the existing Fly volume and machine configuration.
- Confirm the live Fly health endpoint returns HTTP 200.

After merge, the same `main` push should therefore trigger both Streamlit Cloud's linked-branch deployment and the new Fly production workflow.

## Verification

- `55 passed` across all top-level pytest tests.
- 20-worker completion burst test confirms the shared 8-call bound.
- 20-worker SQLite diagnostic test confirms WAL writes without lock failures.
- Streamlit smoke tests cover Playground, Builder, Export, workspace download, and evaluation-result download rendering.
- Production Docker image builds successfully from `Dockerfile`.
- Built container starts with `--server.maxUploadSize=10` and returns `ok` from `/_stcore/health`.
- Live `https://asklit-scaffold-lab.fly.dev/_stcore/health` returns HTTP 200.

## Operational note

The repository Fly deploy token expires on 2027-08-21 and should be rotated before then.
