### PR TITLE
fix(scaffold): stop the prompt editor dropping edits on click-away

### DIFF
--- a/asklit/scaffold/config.py
+++ b/asklit/scaffold/config.py
@@ -66,6 +66,20 @@ def normalize_prompt_profiles(profiles):
     return normalized
 
 
+def profiles_still_using_the_default_prompt(profiles):
+    """Name the prompts nobody has actually written yet.
+
+    A prompt that silently stays at DEFAULT_PROMPT_TEXT reaches evaluation and
+    export looking like a real one, so the scores describe the stock assistant
+    and the deployed prompts/*.yml ships it. Callers warn on a non-empty list.
+    """
+    return [
+        profile["label"]
+        for profile in profiles
+        if str(profile.get("prompt") or "").strip() == DEFAULT_PROMPT_TEXT
+    ]
+
+
 def ensure_model_defaults(config_data):
     """Keep Export usable even when someone skips the AI Model step."""
     model = config_data.setdefault("model", {})

--- a/asklit/scaffold/step_evaluate.py
+++ b/asklit/scaffold/step_evaluate.py
@@ -20,6 +20,7 @@ from asklit.llm import call_llm, get_allowed_models
 from asklit.scaffold.config import (
     ensure_model_defaults,
     normalize_prompt_profiles,
+    profiles_still_using_the_default_prompt,
     provider_options,
 )
 from asklit.scaffold.endpoints import (
@@ -366,6 +367,24 @@ def _render_run_settings(profiles, labels, model_choices, default_model):
     return prompt_keys, knowledgebase_keys, model_names
 
 
+def _warn_about_unwritten_prompts(profiles):
+    """Say so before scoring a prompt the learner never actually wrote.
+
+    A prompt left at the stock text scores badly for a reason that has nothing
+    to do with the scenarios, and the run still costs model calls.
+    """
+    unwritten = profiles_still_using_the_default_prompt(profiles)
+    if not unwritten:
+        return
+    st.warning(
+        "Still using the stock prompt: "
+        + ", ".join(f"`{label}`" for label in unwritten)
+        + ". These runs will score \"You are a helpful assistant.\" rather than "
+        "your own instructions, so expect poor results. Write the prompt in "
+        "**2. Prompt** first."
+    )
+
+
 def _warn_about_unindexed_knowledgebases(profiles, knowledgebase_keys, db_path):
     """Catch the silent failure where a prompt points at an empty knowledge base."""
     counts = knowledgebase_document_counts(db_path)
@@ -606,6 +625,7 @@ def render_evaluate_step():
         "Each combination makes a real model call using credentials configured for this scaffolder. "
         "Your provider may charge for these calls."
     )
+    _warn_about_unwritten_prompts(profiles)
 
     provider, provider_ready, untrusted_custom_endpoint = _render_provider_controls(
         model_config

--- a/asklit/scaffold/step_export.py
+++ b/asklit/scaffold/step_export.py
@@ -32,6 +32,7 @@ from asklit.scaffold.config import (
     DEFAULT_MODEL_NAME,
     ensure_model_defaults,
     normalize_prompt_profiles,
+    profiles_still_using_the_default_prompt,
     provider_options,
 )
 from asklit.scaffold.endpoints import (
@@ -40,6 +41,11 @@ from asklit.scaffold.endpoints import (
 )
 from asklit.scaffold.knowledge import knowledgebase_document_counts
 from asklit.scaffold.step_chat import preview_model_choices
+from asklit.scaffold.step_prompt import (
+    seed_widget_state,
+    sync_conversation_starters,
+    sync_prompt_text,
+)
 from asklit.scaffold.ui import render_password_hash_setup, session_paths
 
 REQUEST_TIMEOUT_SECONDS = 20
@@ -369,29 +375,47 @@ def _render_branding_assets():
 
 
 def _render_prompt_summary():
-    """Last chance to adjust prompt text and starters before publishing."""
+    """Last chance to adjust prompt text and starters before publishing.
+
+    These fields edit the same profiles as step 2, so they use the same keyed
+    autosave: the widget owns its text and an on_change callback writes it into
+    the workspace config. Assigning the widget's return value here instead let
+    a stale value seeded before an edit overwrite the newer text.
+    """
     config = st.session_state.app_config
     profiles = normalize_prompt_profiles(config.get("prompt_profiles"))
     config["prompt_profiles"] = profiles
+    unwritten = profiles_still_using_the_default_prompt(profiles)
+    if unwritten:
+        st.warning(
+            "Still using the stock prompt: "
+            + ", ".join(f"`{label}`" for label in unwritten)
+            + ". Exporting now ships \"You are a helpful assistant.\" as the "
+            "deployed prompt. Edit it below or in **2. Prompt** first."
+        )
     with st.expander("Prompts and conversation starters", expanded=True):
         for index, profile in enumerate(profiles):
             st.markdown(f"**{profile['label']}** · `{profile['knowledgebase']}`")
-            profile["prompt"] = st.text_area(
+            prompt_key = f"export_prompt_{index}"
+            seed_widget_state(prompt_key, profile["prompt"])
+            st.text_area(
                 f"System prompt — {profile['label']}",
-                profile["prompt"],
-                key=f"export_prompt_{index}",
+                key=prompt_key,
                 height=140,
+                on_change=sync_prompt_text,
+                args=(index, prompt_key),
             )
-            profile["conversation_starters"] = [
-                line.strip()
-                for line in st.text_area(
-                    f"Conversation starters — {profile['label']}",
-                    "\n".join(profile.get("conversation_starters", [])),
-                    key=f"export_starters_{index}",
-                    height=90,
-                ).splitlines()
-                if line.strip()
-            ]
+            starters_key = f"export_starters_{index}"
+            seed_widget_state(
+                starters_key, "\n".join(profile.get("conversation_starters", []))
+            )
+            st.text_area(
+                f"Conversation starters — {profile['label']}",
+                key=starters_key,
+                height=90,
+                on_change=sync_conversation_starters,
+                args=(index, starters_key),
+            )
 
 
 def _render_knowledge_summary():

--- a/asklit/scaffold/step_prompt.py
+++ b/asklit/scaffold/step_prompt.py
@@ -10,6 +10,25 @@ from asklit.scaffold.knowledge import (
 )
 from asklit.scaffold.ui import session_paths
 
+# Every editor field carries an explicit key so its in-progress text lives at a
+# stable address in session_state. A keyless widget's id is a hash that includes
+# its current value, so the id changes on every edit and a half-committed change
+# has nowhere to survive: clicking a button while a text area still holds focus
+# races the blur that commits the text, and the edit is dropped.
+# See https://github.com/streamlit/streamlit/issues/8725. With a key plus
+# on_change, the callback runs before the rerun's script body, so the text
+# reaches app_config even when the click that triggered it is swallowed.
+EDITOR_KEY_PREFIXES = (
+    "prompt_label_",
+    "prompt_kb_",
+    "prompt_text_",
+    "prompt_starters_",
+    "prompt_key_",
+    "prompt_files_",
+)
+KB_RENAME_NOTICE_KEY = "prompt_kb_rename_notice"
+PROMPT_INDEX_KEY = "prompt_editor_index"
+
 
 def render_prompt_step():
     """Edit one prompt at a time, with the advanced pairing fields tucked away."""
@@ -23,44 +42,22 @@ def render_prompt_step():
         st.session_state.app_config.get("prompt_profiles")
     )
     st.session_state.app_config["prompt_profiles"] = profiles
-    db_path, chroma_path = session_paths()
 
     selected_index = st.selectbox(
         "Prompt to edit",
         range(len(profiles)),
         format_func=lambda index: profiles[index]["label"],
-        key="prompt_editor_index",
+        key=PROMPT_INDEX_KEY,
         help=(
             "Each prompt becomes its own choice in the deployed chat's sidebar, "
             "with its own knowledge base."
         ),
     )
-    profile = profiles[selected_index]
-    profile["label"] = st.text_input("Prompt name", profile["label"])
-    profile["knowledgebase"] = _render_knowledgebase_field(
-        profile, db_path, chroma_path
-    )
-    profile["prompt"] = st.text_area(
-        "System prompt",
-        profile["prompt"],
-        height=280,
-        help="Describe the assistant's role, audience, boundaries, and desired answer style.",
-    )
-    profile["conversation_starters"] = [
-        line.strip()
-        for line in st.text_area(
-            "Conversation starters",
-            value="\n".join(profile.get("conversation_starters", [])),
-            height=120,
-            help="Add one example question per line. These appear as quick-start buttons in Chat.",
-        ).splitlines()
-        if line.strip()
-    ]
-    _render_advanced_pairing(profile, selected_index, db_path)
-    profile["key"] = slugify_key(profile["label"], profile["key"])
+    render_profile_editor(selected_index)
 
     action_columns = st.columns(2)
     if action_columns[0].button("Add another prompt"):
+        profile = profiles[selected_index]
         next_number = len(profiles) + 1
         profiles.append(
             {
@@ -72,9 +69,11 @@ def render_prompt_step():
                 "connected_files": [],
             }
         )
+        clear_editor_widget_state()
         st.rerun()
     if len(profiles) > 1 and action_columns[1].button("Remove this prompt"):
         profiles.pop(selected_index)
+        clear_editor_widget_state()
         st.rerun()
 
     st.info(
@@ -83,27 +82,203 @@ def render_prompt_step():
     )
 
 
-def _render_knowledgebase_field(profile, db_path, chroma_path):
-    """Rename the knowledge base without orphaning the documents inside it."""
-    previous = profile["knowledgebase"]
-    knowledgebase = slugify_key(
-        st.text_input(
-            "Knowledge-base name",
-            previous,
-            help="Prompts with the same knowledge-base name search the same uploaded sources.",
-        ),
-        previous,
-    )
-    if knowledgebase != previous:
-        # Without this, retrieval silently returns nothing after a rename and the
-        # model answers from general knowledge instead.
-        moved = rename_knowledgebase(previous, knowledgebase, db_path, chroma_path)
-        if moved:
-            st.info(
-                f"Moved {moved} indexed document(s) from `{previous}` to "
-                f"`{knowledgebase}`."
-            )
+@st.fragment
+def render_profile_editor(index):
+    """Render the fields for one prompt.
 
+    This is a fragment so committing a field re-runs only the editor. As a
+    full-page rerun it re-queried SQLite for document counts on every blur,
+    which widened the window in which a click on a button elsewhere on the
+    page was swallowed.
+    """
+    profile = editing_profile(index)
+    if profile is None:
+        return
+    db_path, chroma_path = session_paths()
+
+    label_key = f"prompt_label_{index}"
+    seed_widget_state(label_key, profile["label"])
+    st.text_input(
+        "Prompt name",
+        key=label_key,
+        on_change=_sync_label,
+        args=(index, label_key),
+    )
+    _render_knowledgebase_field(profile, index, db_path, chroma_path)
+    prompt_key = f"prompt_text_{index}"
+    seed_widget_state(prompt_key, profile["prompt"])
+    st.text_area(
+        "System prompt",
+        key=prompt_key,
+        height=280,
+        on_change=sync_prompt_text,
+        args=(index, prompt_key),
+        help="Describe the assistant's role, audience, boundaries, and desired answer style.",
+    )
+    starters_key = f"prompt_starters_{index}"
+    seed_widget_state(starters_key, "\n".join(profile.get("conversation_starters", [])))
+    st.text_area(
+        "Conversation starters",
+        key=starters_key,
+        height=120,
+        on_change=sync_conversation_starters,
+        args=(index, starters_key),
+        help="Add one example question per line. These appear as quick-start buttons in Chat.",
+    )
+    _render_save_control(index, label_key, prompt_key, starters_key)
+    _render_advanced_pairing(profile, index, db_path)
+
+
+def _render_save_control(index, label_key, prompt_key, starters_key):
+    """Give the autosave a visible, tappable commit point.
+
+    Tapping this re-reads every field from session_state and writes it into the
+    workspace, so a learner who cannot press Ctrl/Cmd+Enter — an iPad has no
+    Command key — has an affordance that confirms the prompt is stored rather
+    than having to trust an invisible save.
+    """
+    st.caption(
+        "Your edits save as soon as you tap or click outside a box. You do not "
+        "need to press Ctrl+Enter."
+    )
+    if st.button("Save prompt", key=f"prompt_save_{index}"):
+        _sync_label(index, label_key)
+        sync_prompt_text(index, prompt_key)
+        sync_conversation_starters(index, starters_key)
+        st.success("Prompt saved.")
+
+
+def editing_profile(index):
+    """Return the profile a callback is editing, or None if it has gone away.
+
+    Callbacks fire before the script body, so the profile list can be shorter
+    than it was when the widget was drawn.
+    """
+    profiles = st.session_state.app_config.get("prompt_profiles") or []
+    return profiles[index] if 0 <= index < len(profiles) else None
+
+
+def seed_widget_state(widget_key, value):
+    """Give a keyed widget its starting text without fighting session_state.
+
+    Passing ``value=`` alongside ``key=`` makes Streamlit warn once the key
+    exists, so the stored value is the only default the widget ever sees.
+    """
+    if widget_key not in st.session_state:
+        st.session_state[widget_key] = value
+
+
+def sync_prompt_text(index, widget_key):
+    """Commit the system prompt to the workspace config."""
+    profile = editing_profile(index)
+    if profile is not None:
+        profile["prompt"] = st.session_state[widget_key]
+
+
+def sync_conversation_starters(index, widget_key):
+    """Commit the conversation starters, one per non-blank line."""
+    profile = editing_profile(index)
+    if profile is not None:
+        profile["conversation_starters"] = [
+            line.strip()
+            for line in st.session_state[widget_key].splitlines()
+            if line.strip()
+        ]
+
+
+def _sync_label(index, widget_key):
+    """Commit the prompt name and keep its derived YAML key in step."""
+    profile = editing_profile(index)
+    if profile is None:
+        return
+    label = str(st.session_state[widget_key]).strip()
+    if not label:
+        # A blank name slugifies to nothing, which would orphan the YAML key.
+        st.session_state[widget_key] = profile["label"]
+        return
+    profile["label"] = label
+    profile["key"] = slugify_key(label, profile["key"])
+    st.session_state[f"prompt_key_{index}"] = profile["key"]
+
+
+def _sync_knowledgebase(index, widget_key, db_path, chroma_path):
+    """Commit the knowledge-base name, moving its documents when it changes."""
+    profile = editing_profile(index)
+    if profile is None:
+        return
+    previous = profile["knowledgebase"]
+    knowledgebase = slugify_key(st.session_state[widget_key], previous)
+    # Show the slug the rest of the app will actually use, not the raw typing.
+    st.session_state[widget_key] = knowledgebase
+    if knowledgebase == previous:
+        return
+    profile["knowledgebase"] = knowledgebase
+    # Without this, retrieval silently returns nothing after a rename and the
+    # model answers from general knowledge instead.
+    moved = rename_knowledgebase(previous, knowledgebase, db_path, chroma_path)
+    if moved:
+        # Callbacks cannot draw, so the message waits for the rerun they cause.
+        st.session_state[KB_RENAME_NOTICE_KEY] = (
+            f"Moved {moved} indexed document(s) from `{previous}` to "
+            f"`{knowledgebase}`."
+        )
+
+
+def _sync_yaml_key(index, widget_key):
+    """Commit a hand-edited YAML key, falling back to the existing slug."""
+    profile = editing_profile(index)
+    if profile is None:
+        return
+    profile["key"] = slugify_key(st.session_state[widget_key], profile["key"])
+    st.session_state[widget_key] = profile["key"]
+
+
+def _sync_connected_files(index, widget_key, available):
+    """Store the file selection, treating 'everything' as an empty list.
+
+    An empty list means "every file in this knowledge base", so selecting them
+    all is stored that way and later uploads are included too.
+    """
+    profile = editing_profile(index)
+    if profile is None:
+        return
+    selected = st.session_state[widget_key]
+    profile["connected_files"] = (
+        [] if not selected or set(selected) == set(available) else list(selected)
+    )
+
+
+def clear_editor_widget_state():
+    """Drop the keyed editor widgets so they re-seed from the workspace config.
+
+    The keys are index-based, so adding or removing a prompt would otherwise
+    leave one profile's text showing under another profile's index.
+    """
+    stale = [
+        state_key
+        for state_key in st.session_state
+        if state_key.startswith(EDITOR_KEY_PREFIXES)
+    ]
+    for state_key in stale:
+        del st.session_state[state_key]
+
+
+def _render_knowledgebase_field(profile, index, db_path, chroma_path):
+    """Rename the knowledge base without orphaning the documents inside it."""
+    widget_key = f"prompt_kb_{index}"
+    seed_widget_state(widget_key, profile["knowledgebase"])
+    st.text_input(
+        "Knowledge-base name",
+        key=widget_key,
+        on_change=_sync_knowledgebase,
+        args=(index, widget_key, db_path, chroma_path),
+        help="Prompts with the same knowledge-base name search the same uploaded sources.",
+    )
+    rename_notice = st.session_state.pop(KB_RENAME_NOTICE_KEY, None)
+    if rename_notice:
+        st.info(rename_notice)
+
+    knowledgebase = profile["knowledgebase"]
     indexed_count = knowledgebase_document_counts(db_path).get(knowledgebase, 0)
     if indexed_count:
         st.caption(f"`{knowledgebase}` currently holds {indexed_count} document(s).")
@@ -112,20 +287,19 @@ def _render_knowledgebase_field(profile, db_path, chroma_path):
             f"No indexed documents belong to `{knowledgebase}` yet. Upload some in "
             "**1. Knowledge**, or this prompt will answer without any sources."
         )
-    return knowledgebase
 
 
 def _render_advanced_pairing(profile, index, db_path):
     """Expose the deployment-level pairing fields without cluttering the step."""
     with st.expander("Advanced: deployment details for this prompt", expanded=False):
-        profile["key"] = slugify_key(
-            st.text_input(
-                "YAML key",
-                profile["key"],
-                key=f"prompt_key_{index}",
-                help="Used for the prompt's YAML filename and admin overrides.",
-            ),
-            profile["key"],
+        yaml_key = f"prompt_key_{index}"
+        seed_widget_state(yaml_key, profile["key"])
+        st.text_input(
+            "YAML key",
+            key=yaml_key,
+            on_change=_sync_yaml_key,
+            args=(index, yaml_key),
+            help="Used for the prompt's YAML filename and admin overrides.",
         )
         available = [
             document["filename"]
@@ -139,23 +313,25 @@ def _render_advanced_pairing(profile, index, db_path):
             )
             return
 
+        files_key = f"prompt_files_{index}"
         configured = profile.get("connected_files") or []
-        selected = st.multiselect(
+        seed_widget_state(
+            files_key,
+            [name for name in configured if name in available] or available,
+        )
+        st.multiselect(
             "Connected files",
             available,
-            default=[name for name in configured if name in available] or available,
-            key=f"prompt_files_{index}",
+            key=files_key,
+            on_change=_sync_connected_files,
+            args=(index, files_key, available),
             help=(
                 "Leave every file selected to search the whole knowledge base, "
                 "including anything you upload later. Narrow it to restrict this "
                 "prompt to specific documents."
             ),
         )
-        # An empty list means "every file in this knowledge base", so selecting
-        # them all is stored that way and later uploads are included too.
-        profile["connected_files"] = (
-            [] if not selected or set(selected) == set(available) else selected
-        )
+        _sync_connected_files(index, files_key, available)
         if not profile["connected_files"]:
             st.caption(
                 f"Searching every document in `{profile['knowledgebase']}`, "

--- a/requirements-fly.txt
+++ b/requirements-fly.txt
@@ -1,4 +1,4 @@
-streamlit
+streamlit==1.59.2
 chromadb
 protobuf==3.20.3
 litellm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-streamlit
+streamlit==1.59.2
 chromadb
 protobuf==3.20.3
 litellm

--- a/test_scaffold_app.py
+++ b/test_scaffold_app.py
@@ -1,6 +1,7 @@
 """End-to-end checks of the scaffolder's single workflow via Streamlit's AppTest."""
 
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -259,3 +260,174 @@ def test_carrying_a_result_forward_updates_the_exported_configuration():
     assert model_config["name"] == "m1"  # the higher pass rate
     assert model_config["provider"] == "openai"
     assert any("will default to" in success.value for success in app.success)
+
+
+def _next_button(app):
+    return [button for button in app.button if button.label.startswith("Next")][0]
+
+
+def _action_button(app, label):
+    return [button for button in app.button if button.label == label][0]
+
+
+def test_prompt_edits_survive_a_click_that_leaves_the_step():
+    """Typing must reach the workspace even when a button click ends the step.
+
+    Streamlit commits a text area on blur, so clicking a button while the box
+    still holds focus races that blur and the edit used to be dropped
+    (streamlit/streamlit#8725). Queueing both interactions into one run is the
+    closest AppTest gets to that race; the keyed widgets and their on_change
+    callbacks are what make the text land in app_config either way.
+    """
+    app = run_app("2. Prompt")
+    app.text_area("prompt_text_0").set_value("Only answer from the uploaded cases.")
+    _next_button(app).click()
+    app.run()
+
+    assert not app.exception
+    assert app.header[0].value != "Write a prompt", "the Next click was swallowed"
+    profiles = app.session_state["app_config"]["prompt_profiles"]
+    assert profiles[0]["prompt"] == "Only answer from the uploaded cases."
+
+
+def test_conversation_starters_survive_a_click_that_leaves_the_step():
+    app = run_app("2. Prompt")
+    app.text_area("prompt_starters_0").set_value("What is a continuance?\n\nCan I appeal?")
+    _next_button(app).click()
+    app.run()
+
+    profiles = app.session_state["app_config"]["prompt_profiles"]
+    assert profiles[0]["conversation_starters"] == [
+        "What is a continuance?",
+        "Can I appeal?",
+    ]
+
+
+def test_the_export_step_edits_the_prompt_instead_of_overwriting_it():
+    """Export repeats the prompt fields, so it must not restore stale text."""
+    app = run_app("2. Prompt")
+    app.text_area("prompt_text_0").set_value("Cite the statute section.").run()
+    app.sidebar.radio[0].set_value("5. Export").run()
+
+    assert app.text_area("export_prompt_0").value == "Cite the statute section."
+
+    app.text_area("export_prompt_0").set_value("Cite the statute and the year.").run()
+    profiles = app.session_state["app_config"]["prompt_profiles"]
+    assert profiles[0]["prompt"] == "Cite the statute and the year."
+
+
+def test_switching_prompts_does_not_carry_text_between_them():
+    app = run_app("2. Prompt")
+    app.text_area("prompt_text_0").set_value("First prompt text.").run()
+    _action_button(app, "Add another prompt").click().run()
+    app.selectbox("prompt_editor_index").set_value(1).run()
+    app.text_area("prompt_text_1").set_value("Second prompt text.").run()
+    app.selectbox("prompt_editor_index").set_value(0).run()
+
+    assert app.text_area("prompt_text_0").value == "First prompt text."
+    profiles = app.session_state["app_config"]["prompt_profiles"]
+    assert [profile["prompt"] for profile in profiles] == [
+        "First prompt text.",
+        "Second prompt text.",
+    ]
+
+
+def test_removing_a_prompt_leaves_the_survivor_showing_its_own_text():
+    """Editor keys are index-based, so a removal has to reset them.
+
+    Dropping the first of two profiles shifts the second into index 0. Without
+    clearing the keyed widgets, index 0 kept the removed prompt's text on
+    screen and the next blur wrote it over the survivor.
+    """
+    app = run_app("2. Prompt")
+    app.text_area("prompt_text_0").set_value("Doomed prompt.").run()
+    _action_button(app, "Add another prompt").click().run()
+    app.selectbox("prompt_editor_index").set_value(1).run()
+    app.text_area("prompt_text_1").set_value("Surviving prompt.").run()
+
+    app.selectbox("prompt_editor_index").set_value(0).run()
+    _action_button(app, "Remove this prompt").click().run()
+
+    assert not app.exception
+    profiles = app.session_state["app_config"]["prompt_profiles"]
+    assert [profile["prompt"] for profile in profiles] == ["Surviving prompt."]
+    assert app.text_area("prompt_text_0").value == "Surviving prompt."
+
+
+def test_a_prompt_typed_in_the_editor_reaches_the_deployed_yaml(tmp_path):
+    """Reproduce the classroom report: the exported YAML kept the stock prompt.
+
+    A student typed a system prompt, could not press the Ctrl/Cmd+Enter the
+    caption asked for, and moved on. The keyless text area dropped the edit, so
+    app_config still held DEFAULT_PROMPT_TEXT — which then flowed into the
+    evaluation and into prompts/*.yml, and the exported app shipped with
+    "You are a helpful assistant."
+    """
+    import yaml
+    from asklit.db import init_db
+    from asklit.scaffold import bundle as bundle_module
+    from asklit.scaffold.config import DEFAULT_PROMPT_TEXT
+
+    student_prompt = (
+        "You are a Massachusetts housing advisor. Answer only from the "
+        "retrieved passages and say so when they are silent."
+    )
+
+    app = run_app("2. Prompt")
+    app.text_area("prompt_text_0").set_value(student_prompt)
+    _next_button(app).click()
+    app.run()
+
+    profiles = app.session_state["app_config"]["prompt_profiles"]
+    assert profiles[0]["prompt"] == student_prompt, "the editor dropped the prompt"
+    assert profiles[0]["prompt"] != DEFAULT_PROMPT_TEXT
+
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    init_db(str(session_dir / "app.sqlite3"))
+    bundle_dir = Path(
+        bundle_module.create_bundle(
+            app.session_state["app_config"], str(session_dir)
+        )
+    )
+
+    exported = yaml.safe_load(
+        (bundle_dir / "prompts" / f"{profiles[0]['key']}.yml").read_text()
+    )
+    assert exported["prompt"] == student_prompt
+
+
+def test_the_save_button_commits_the_prompt_on_its_own():
+    """The button must store the text without relying on a blur first.
+
+    This is the affordance for a learner who cannot press Ctrl/Cmd+Enter, so
+    it re-reads the fields rather than trusting that on_change already fired.
+    """
+    app = run_app("2. Prompt")
+    app.text_area("prompt_text_0").set_value("Answer only from the record.")
+    _action_button(app, "Save prompt").click()
+    app.run()
+
+    assert not app.exception
+    profiles = app.session_state["app_config"]["prompt_profiles"]
+    assert profiles[0]["prompt"] == "Answer only from the record."
+    assert any("Prompt saved." in success.value for success in app.success)
+
+
+@pytest.mark.parametrize("step_label", ["4. Evaluate", "5. Export"])
+def test_an_unwritten_prompt_is_called_out_before_it_costs_anything(step_label):
+    """A prompt left at the stock text used to sail silently into both steps."""
+    app = run_app(step_label)
+
+    assert any(
+        "stock prompt" in warning.value for warning in app.warning
+    ), f"{step_label} did not flag the default prompt"
+
+
+@pytest.mark.parametrize("step_label", ["4. Evaluate", "5. Export"])
+def test_a_written_prompt_is_not_flagged(step_label):
+    app = run_app("2. Prompt")
+    app.text_area("prompt_text_0").set_value("Answer only from the record.").run()
+    app.sidebar.radio[0].set_value(step_label).run()
+
+    assert not any("stock prompt" in warning.value for warning in app.warning)


### PR DESCRIPTION
## The report

> I went through all the steps and my evaluation was really poor. I opened the Yaml file and it didn't save my prompt, I don't think. Under the prompt box it says to command enter but I have an iPad that doesn't have a command key.

Three symptoms, one defect. Driving the pre-fix build the way the report describes — type a system prompt, tap **Next**, no Ctrl/Cmd+Enter — reproduces it:

```
pre-fix:   prompt stored in app_config: 'You are a helpful assistant.'   → LOST
post-fix:  prompt stored in app_config: 'You are a Massachusetts housing advisor…' → kept
```

`"You are a helpful assistant."` is `DEFAULT_PROMPT_TEXT`. The prompt wasn't mangled, it was never committed, and the default flowed downstream untouched:

- **YAML had the stock prompt** — `bundle.py:135` writes `profile["prompt"]` straight into `prompts/<key>.yml`.
- **Evaluation scored poorly** — step 4 scores the same profiles, so it graded a bare "You are a helpful assistant." with no grounding instruction. The bad score was correct for what was actually tested.
- **Cmd+Enter was the only affordance** — Streamlit renders that caption as ⌘+Enter on Mac and iOS. A student on an iPad had no offered way to commit.

## Cause

`st.text_area` sends its value on **blur** or **Ctrl+Enter**, never per keystroke. Clicking a button fires `blur` and `click` microseconds apart as two messages that can land in either order ([streamlit#8725](https://github.com/streamlit/streamlit/issues/8725)).

The editor's fields were keyless, so Streamlit derived each widget id by hashing its label *and current value*. The id changed on every edit, so an in-flight change had no stable address to survive in — the only copy was the return value. `render_next_step_button` uses `on_click`, so on the swallowing run the editor didn't render at all and that assignment never happened.

## Fix

Stable `key=` plus an `on_change` callback on every field, writing into `app_config`. Callbacks run *before* the rerun's script body, so the text lands even when the click that triggered it is swallowed — the worst case degrades from "your prompt vanished" to "Next needed a second tap." The editor is wrapped in `@st.fragment` so a commit no longer re-runs the whole page (it was re-querying SQLite for document counts on every blur, widening the window).

Also here:
- Export step repeated these fields and assigned return values back into the profile, so a stale seeded value could overwrite newer text. Same pattern applied.
- Index-keyed widgets are cleared on add/remove so a survivor can't inherit a neighbour's text.
- A **Save prompt** button as a visible, tappable commit point, alongside the autosave rather than instead of it.
- A **stock-prompt warning** in steps 4 and 5. This wouldn't have prevented the bug, but it would have told the student *why* their scores were bad instead of leaving them to open the YAML and guess. It catches any future cause of the same silent failure.
- `streamlit==1.59.2` pinned in both requirements files. It carries [streamlit#10018](https://github.com/streamlit/streamlit/pull/10018), which defers button triggers behind input sync so a mobile **tap** can't outrun the commit — the exact iPad case. `bundle.py:20` copies `requirements.txt` into every exported app, so students' deployments get the pin too.

## Verification

11 new tests in `test_scaffold_app.py`, including one that walks the student's whole path — edit in step 2, navigate away, build the bundle, assert `prompts/*.yml` carries their text and not the default. Four fail against the pre-fix code; the removal test was confirmed by reverting just the state-clearing call. Warning tests come in positive/negative pairs so it can't become unconditional or silently vanish.

Full suite: **125 passed** (`--ignore=tmp`; a stale `tmp/deploy-clean-*` copy causes a pre-existing collection conflict, unrelated).

Deployed to `asklit-scaffold-lab` and verified inside the running container:

```
streamlit_version:         1.59.2
keyed_widget:              present
save_button:               True
prompt_after_nav:          'You are a Massachusetts housing advisor…'
result:                    KEPT
save_button_commits:       True
stock_notice 4. Evaluate:  True
stock_notice 5. Export:    True
```

## Not covered

The **touch gesture on real iPad hardware**. `AppTest` has no touch events, so this verifies commit logic in the deployed container, not Safari's blur behaviour on the device. Worth having the student confirm: type a sentence, tap Next without dismissing the keyboard, return to step 2.

Separately, [streamlit#13326](https://github.com/streamlit/streamlit/issues/13326) reports Streamlit not rendering at all on iPad Safari since iOS 26 (filed against 1.52.0; I could not determine a fix version). Unrelated to this — it shows as a blank page, not lost text — but it's the other thing that could block an iPad user. Chrome on the iPad was the reporter's workaround.

`data/app.sqlite3` is left out of this commit; it was already modified before this work and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJR6wAX6gUsRGzqxzsWbbs
